### PR TITLE
fix(docgen): correctly handle array syntax in callbacks

### DIFF
--- a/packages/titanium-docgen/generators/html_generator.js
+++ b/packages/titanium-docgen/generators/html_generator.js
@@ -418,7 +418,15 @@ function exportType(api) {
 				// Parse out the multiple types of args!
 				const subTypes = t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'));
 				// split by ', ' then convert to link for each and join by ', '
-				const linkified = subTypes.split(',').map(t => convertAPIToLink(t.trim())).join(', ');
+				const linkified = subTypes.split(',').map(t =>  {
+					t = t.trim();
+					if (t.startsWith('Array<')) {
+						const apiName = /Array<(.+)>/.exec(t);
+						return convertAPIToLink(apiName[1]);
+					} else {
+						return convertAPIToLink(t);
+					}
+				}).join(', ');
 				t = `Callback&lt;${linkified}&gt;`;
 			} else if (t.indexOf('Dictionary<') === 0) {
 				t = 'Dictionary&lt;' + convertAPIToLink(t.substring(t.indexOf('<') + 1, t.lastIndexOf('>'))) + '&gt;';


### PR DESCRIPTION
This is a porting of https://github.com/appcelerator/titanium_mobile/pull/11052/commits/c760b75156f2827409be12ebf17b3a100d72aecd