### PR TITLE
fix(versioning): include non-locale sidebar config in snapshot

### DIFF
--- a/packages/vuepress/vuepress-plugin-versioning/lib/util.js
+++ b/packages/vuepress/vuepress-plugin-versioning/lib/util.js
@@ -4,7 +4,7 @@ const path = require('path')
 async function snapshotSidebar (siteConfig, versionDestPath) {
   const sidebarConfig = {
     locales: siteConfig.themeConfig.locales,
-    sidebar: siteConfig.sidebar
+    sidebar: siteConfig.themeConfig.sidebar
   }
 
   return fs.writeFile(path.join(versionDestPath, 'sidebar.config.json'), JSON.stringify(sidebarConfig, null, 2))


### PR DESCRIPTION
Fix sidebar snapshot to properly include the non-locale sidebar config which is found under `themeConfig` instead of the root of the config object.