### PR TITLE
fix(docgen): allow Error and RegExp as predefined types

### DIFF
--- a/packages/titanium-docgen/lib/common.js
+++ b/packages/titanium-docgen/lib/common.js
@@ -30,7 +30,9 @@ exports.ADDON_VERSIONS = {
 	blackberry: '3.1.2',
 	windowsphone: '4.1.0'
 };
-exports.DATA_TYPES = [ 'Array', 'Boolean', 'Callback', 'Date', 'Dictionary', 'Number', 'Object', 'String' ];
+
+// TODO: Add null, undefined, Arguments, Function?
+exports.DATA_TYPES = [ 'Array', 'Boolean', 'Callback', 'Date', 'Dictionary', 'Number', 'Object', 'String', 'Error', 'RegExp' ];
 exports.PRETTY_PLATFORM = {
 	android: 'Android',
 	blackberry: 'BlackBerry',


### PR DESCRIPTION
If I reference Error or RegEx types in our apidocs, we get an error. These are core pre-defined types in JS, and should be allowed. 

(for reference, the legacy doc publishing process uses Sencha/jsduck and also supports these types: https://github.com/senchalabs/jsduck/wiki/Type-Definitions - note that we will eventually have issues with es6+ types there).