### PR TITLE
feat(docgen): improve validation to include warnings

### DIFF
--- a/packages/titanium-docgen/validate.js
+++ b/packages/titanium-docgen/validate.js
@@ -13,9 +13,8 @@ const fs = require('fs'),
 	colors = require('colors'), // eslint-disable-line no-unused-vars
 	common = require('./lib/common.js');
 
-let doc = {},
-	errorCount = 0,
-	standaloneFlag = false;
+let doc = {};
+let standaloneFlag = false;
 
 // List of "whitelisted" types provided via cli flag
 // if we are unable to find these types we do not error
@@ -26,6 +25,9 @@ const whitelist = [];
 const WINDOWS_CONSTANTS = [
 	'Titanium.UI.Windows.ListViewScrollPosition.*'
 ];
+
+const AVAILABILITY = [ 'always', 'creation', 'not-creation' ];
+const PERMISSIONS = [ 'read-only', 'write-only', 'read-write' ];
 
 const Examples = [ {
 	required: {
@@ -44,6 +46,17 @@ const Deprecated = {
 	}
 };
 
+// TODO: Replace validateReturns with this once we fix docs to not have array of returns (when they should instead have an array of type under returns)
+// const Returns = {
+// 	required: {
+// 		type: 'DataType' // FIXME: also needs to handle void
+// 	},
+// 	optional: {
+// 		summary: 'String',
+// 		constants: 'Constants'
+// 	}
+// };
+
 const validSyntax = {
 	required: {
 		name: 'String',
@@ -52,8 +65,8 @@ const validSyntax = {
 	optional: {
 		description: 'Markdown',
 		createable: 'Boolean',
-		platforms: [ common.VALID_PLATFORMS ],
-		'exclude-platforms': [ common.VALID_PLATFORMS ],
+		platforms: 'Platforms',
+		'exclude-platforms': 'Platforms',
 		excludes: {
 			optional: {
 				events: 'Array<events.name>',
@@ -73,7 +86,7 @@ const validSyntax = {
 			},
 			optional: {
 				description: 'String',
-				platforms: [ common.VALID_PLATFORMS ],
+				platforms: 'Platforms',
 				since: 'Since',
 				deprecated: Deprecated,
 				osver: 'OSVersions',
@@ -85,14 +98,14 @@ const validSyntax = {
 					},
 					optional: {
 						optional: 'Boolean',
-						platforms: [ common.VALID_PLATFORMS ],
+						platforms: 'Platforms',
 						deprecated: Deprecated,
 						since: 'Since',
-						'exclude-platforms': [ common.VALID_PLATFORMS ],
+						'exclude-platforms': 'Platforms',
 						constants: 'Constants'
 					}
 				} ],
-				'exclude-platforms': [ common.VALID_PLATFORMS ],
+				'exclude-platforms': 'Platforms',
 				notes: 'Invalid'
 			}
 		} ],
@@ -103,8 +116,8 @@ const validSyntax = {
 			},
 			optional: {
 				description: 'String',
-				returns: 'Returns', // FIXME Validate 'Returns' has a required 'type' String property
-				platforms: [ common.VALID_PLATFORMS ],
+				returns: 'Returns',
+				platforms: 'Platforms',
 				since: 'Since',
 				deprecated: Deprecated,
 				examples: Examples,
@@ -123,7 +136,7 @@ const validSyntax = {
 						notes: 'Invalid'
 					}
 				} ],
-				'exclude-platforms': [ common.VALID_PLATFORMS ],
+				'exclude-platforms': 'Platforms',
 				notes: 'Invalid'
 			}
 		} ],
@@ -135,18 +148,18 @@ const validSyntax = {
 			},
 			optional: {
 				description: 'String',
-				platforms: [ common.VALID_PLATFORMS ],
+				platforms: 'Platforms',
 				since: 'Since',
 				deprecated: Deprecated,
 				osver: 'OSVersions',
 				examples: Examples,
-				permission: [ 'read-only', 'write-only', 'read-write' ], // FIXME Enforce permission must be set to 'read-only' if name of property is all caps: [A-Z]+[A-Z_]*
-				availability: [ 'always', 'creation', 'not-creation' ],
+				permission: 'Permission',
+				availability: 'Availability',
 				accessors: 'Boolean',
 				optional: 'Boolean',
 				value: 'Primitive',
 				default: 'Default',
-				'exclude-platforms': [ common.VALID_PLATFORMS ],
+				'exclude-platforms': 'Platforms',
 				constants: 'Constants',
 				notes: 'Invalid'
 			}
@@ -154,44 +167,80 @@ const validSyntax = {
 	}
 };
 
+// We define issues in the apidocs as Problem instances with severities
+// this way we can warn about issues but not have them fail validation
+const ERROR = 1;
+const WARNING = 2;
+const INFO = 3;
+class Problem {
+	/**
+	 * @param {string} message the message giving details of the problem
+	 * @param {1|2|3} [severity=1] severity level of this problem
+	 */
+	constructor(message, severity = ERROR) {
+		this.message = message;
+		this.severity = severity;
+	}
+
+	isWarning() {
+		return this.severity === WARNING;
+	}
+
+	isError() {
+		return this.severity === ERROR;
+	}
+
+	isInfo() {
+		return this.severity === INFO;
+	}
+
+	toString() {
+		return this.message;
+	}
+}
+
 /**
  * Validate if an API exists in a class and its ancestors
- * @param {Array<String>} obj Array of API names to verify
- * @param {string} type API type ('event', 'methods' or 'properties')
+ * We use this to validate "excludes" references refer to methods/properties/events that actually exist on parents
+ * @param {string[]} names Array of API names to verify
+ * @param {'events'|'methods'|'properties'} type API type
  * @param {string} className Name of class to check
- * @returns {string} Error with unverified API names or null if no errors
+ * @returns {null|Problem} possible Problem
  */
-function validateAPINames(obj, type, className) {
-	const apis = doc[className][type];
+function validateAPINames(names, type, className) {
+	const apis = doc[className][type]; // grab the type's events/properties/methods
+	// This modifies the 'names' arrays as we go, removing entries where we've found a match
 	if (apis) {
 		apis.forEach(function (api) {
-			const index = obj.indexOf(api.name);
+			const index = names.indexOf(api.name);
 			if (~index) {
-				obj.splice(index);
+				names.splice(index);
 			}
 		});
 	}
 	if (type === 'methods' && 'properties' in doc[className]) {
 		// Evaluate setters and getters
+		// if we're looking for getProp/setProp and the type has a declared property for the same name, match it up
 		doc[className].properties.forEach(function (property) {
-			const basename = property.name.charAt(0).toUpperCase() + property.name.slice(1),
-				setter = 'set' + basename,
-				getter = 'get' + basename;
-			let index = obj.indexOf(setter);
-			if (~index) {
-				obj.splice(index);
+			const Prop = property.name.charAt(0).toUpperCase() + property.name.slice(1);
+			const setterIndex = names.indexOf(`set${Prop}`);
+			if (~setterIndex) {
+				names.splice(setterIndex);
 			}
-			index = obj.indexOf(getter);
-			if (~index) {
-				obj.splice(index);
+
+			const getterIndex = names.indexOf(`get${Prop}`);
+			if (~getterIndex) {
+				names.splice(getterIndex);
 			}
 		});
 	}
+
 	if ('extends' in doc[className]) {
 		// Evaluate parent class
 		const parent = doc[className]['extends'];
 		if (parent in doc) {
-			return validateAPINames(obj, type, parent);
+			// the parent type exists, so recurse with remaining api names against the parent
+			return validateAPINames(names, type, parent);
 		}
 
 		// This is a whitelisted type, so ignore it
@@ -204,77 +253,119 @@ function validateAPINames(obj, type, className) {
 			return;
 		}
 
-		return 'Invalid parent class: ' + parent;
+		// TODO: Also make note of remaining apis we haven't matched?
+		return new Problem(`Invalid parent class: ${parent}`);
 	}
-	if (obj.length > 0) {
-		return 'Could not find: ' + obj;
+
+	// We still have unmatched (not found) apis
+	if (names.length > 0) {
+		return new Problem(`Could not find the following ${type}: ${names}`);
 	}
+
+	// All good
+	return null;
 }
 
 /**
  * Validate boolean type
- * @param {Object} bool possible boolean value
- * @return {string} error string if not a boolean
+ * @param {*} bool possible boolean value
+ * @return {null|Problem} possible Problem if not a boolean
  */
 function validateBoolean(bool) {
 	if (typeof bool !== 'boolean') {
-		return 'Not a boolean value: ' + bool;
+		return new Problem(`Not a boolean value: ${bool}`);
 	}
+	return null;
 }
 
 /**
  * Validate class is in docs
- * @param {string} cls class name
- * @returns {string} error string if not found in docs
+ * @param {string} className class name
+ * @returns {null|Problem} possible Problem if not found in docs
  */
-function validateClass(cls) {
-	if (!(cls in doc)) {
-		return 'Not a valid class: ' + cls;
+function validateClass(className) {
+	if (!(className in doc)) {
+		if (standaloneFlag) {
+			return new Problem(`Cannot validate class: ${className} (standalone flag is set)`, WARNING);
+		}
+		if (whitelist.includes(className)) {
+			return null;
+		}
+		return new Problem(`Not a valid or known class/type: ${className}`);
 	}
+	return null;
 }
 
 /**
  * Validate constant is in docs
- * @param {Array|string} constants arry or string of constant names
- * @returns {Array<string>} array of error strings if any given constants weren't found in the docs
+ * @param {string|string[]} constants arry or string of constant names
+ * @returns {Problem[]} array of Problems if any given constants weren't found in the docs
  */
 function validateConstants(constants) {
-	let errors = [];
-	if (Array.isArray(constants)) {
-		constants.forEach(function (constant) {
-			errors = errors.concat(validateConstants(constant));
-		});
-	} else {
-		// skip windows constants that are OK, but would be marked invalid
-		if (WINDOWS_CONSTANTS.includes(constants)) {
-			return errors;
+	const errors = [];
+	// "coerce" to Array
+	constants = Array.isArray(constants) ? constants : [ constants ];
+	// validate each one
+	constants.forEach(c => {
+		const possibleProblem = validateConstant(c);
+		if (possibleProblem) {
+			errors.push(possibleProblem);
 		}
-		let prop = constants.split('.').pop();
-		const cls = constants.substring(0, constants.lastIndexOf('.'));
-		if (!(cls in doc) || !('properties' in doc[cls]) || doc[cls] === null) {
-			errors.push('Invalid constant: ' + constants);
-		} else {
-			const properties = doc[cls].properties;
-			if (prop.charAt(prop.length - 1) === '*') {
-				prop = prop.substring(0, prop.length - 1);
-			}
-			for (let i = 0; i < properties.length; i++) {
-				if (properties[i].name.indexOf(prop) === 0) {
-					return errors;
-				}
-			}
-			errors.push('Invalid constant: ' + constants);
-		}
-	}
+	});
 	return errors;
+}
+
+/**
+ * @param {string} constant name of the referenced constant
+ * @returns {null|Problem} possible Problem
+ */
+function validateConstant(constant) {
+	// skip windows constants that are OK, but would be marked invalid
+	if (WINDOWS_CONSTANTS.includes(constant)) {
+		return null;
+	}
+
+	// is it hanging on a real type (that has properties, so therefore would have constants)
+	const typeName = constant.substring(0, constant.lastIndexOf('.'));
+	if (!(typeName in doc) || !('properties' in doc[typeName]) || doc[typeName] === null) {
+		return new Problem(`Invalid constant: ${constant}, type ${typeName} does not exist`);
+	}
+
+	const propertyNames = doc[typeName].properties.map(p => p.name);
+	// Grab the last segment of the namespace (the "base name")
+	const propertyBaseName = constant.split('.').pop();
+
+	// check for wildcard references!
+	if (propertyBaseName.charAt(propertyBaseName.length - 1) === '*') {
+		// TODO: Report a problem for wildcards? Maybe warning for now?
+
+		const wildcardPrefix = propertyBaseName.substring(0, propertyBaseName.length - 1);
+		// check that we have at least one property matching this prefix?
+		for (let i = 0; i < propertyNames.length; i++) {
+			if (propertyNames[i].indexOf(wildcardPrefix) === 0) {
+				// found it!
+				return null;
+			}
+		}
+		// didn't find it!
+		return new Problem(`Invalid constant: ${constant}`);
+	}
+
+	// Can we find this constant listed as a property on the referenced type/class?
+	if (!propertyNames.includes(propertyBaseName)) {
+		return new Problem(`Invalid constant: ${constant}`);
+	}
+	return null;
 }
 
 /**
  * Validate type
  * @param {string|string[]} type array of strings, or single string with a type name
- * @returns {string[]} array of error strings
+ * @param {string|null} fullTypeContext full context of the type (for recursion), i.e. 'Callback<Object>' or 'Array<Object>'
+ * @returns {Problem[]} problems (may be empty)
  */
-function validateDataType(type) {
+// FIXME: Some types may only be valid in some scenarios, i.e. 'void' for return type/callback arg (which is really 'undefined')
+function validateDataType(type, fullTypeContext) {
 	if (Array.isArray(type)) {
 		const errors = [];
 		type.forEach(elem => {
@@ -283,6 +374,7 @@ function validateDataType(type) {
 		return errors;
 	}
 
+	// Check for compound types: Array<>, Callback<>, Function<>, Dictionary<>
 	const lessThanIndex = type.indexOf('<');
 	const greaterThanIndex = type.lastIndexOf('>');
 	if (lessThanIndex !== -1 && greaterThanIndex !== -1) {
@@ -293,105 +385,172 @@ function validateDataType(type) {
 		const baseType = type.slice(0, lessThanIndex);
 		const subType = type.slice(lessThanIndex + 1, greaterThanIndex);
 		if (baseType === 'Callback' || baseType === 'Function') {
+			// functions can have multiple arguments as sub-types...
 			const errors = [];
 			subType.split(',').forEach(sub => {
-				errors.push(...validateDataType(sub.trim()));
+				errors.push(...validateDataType(sub.trim(), type));
 			});
 			return errors;
 		}
+		// arrays and dictionaries can only have a single argument
 		if (baseType !== 'Array' && baseType !== 'Dictionary') {
-			return [ `Base type for complex types must be one of Array, Callback, Dictionary, Function, but received ${baseType}` ];
+			return [ new Problem(`Base type for complex types must be one of Array, Callback, Dictionary, Function, but received ${baseType}`) ];
 		}
-		return validateDataType(subType);
+		// If we have an Array<Object> should we complain about that too?
+		return validateDataType(subType, type);
 	}
 
-	// This is awkward and backwards, but if the class is valid OR it's a common type, there's no error, so return empty array
-	if (!validateClass(type) || ~common.DATA_TYPES.indexOf(type)) {
+	// Warn about generic Dictonary/Object types
+	if (['Dictionary', 'Object'].includes(type)) {
+		// TODO: How can we mark/skip the valid cases here? Some APIs really do need to say "Object" as the arg/return value
+		return [ new Problem(`Please define a new type rather than using the generic Object/Dictionary references: ${fullTypeContext ? fullTypeContext : type}`, WARNING) ];
+	}
+
+	// Is this a built in Javascript type?
+	if (common.DATA_TYPES.includes(type)) {
 		return [];
 	}
 
-	// Type is whiteslisted, so assume it's "valid"
-	if (whitelist.includes(type)) {
-		return [];
+	// Is this a type in our APIDocs, or on our whitelist? (or are we on standalone mode?)
+	const possibleProblem = validateClass(type);
+	if (possibleProblem) {
+		return [ possibleProblem ];
 	}
 
-	if (standaloneFlag) {
-		// For standalone mode, log warning but not an error
-		// Data type can exist in a parent class not in the data set
-		console.warn('WARNING! Could not validate data type: %s'.yellow, type);
-		return [];
-	}
-	return [ type ];
+	// class/type is fine or whitelisted
+	return [];
 }
 
 /**
  * Validate default value
- * @param {object} val possible primitive or object
- * @returns {string} error string if not a primitive or object
+ * @param {*} val possible primitive or object
+ * @returns {null|Problem} possible Problem if not a primitive or object
  */
 function validateDefault(val) {
 	if (validatePrimitive(val) && (typeof val !== 'object')) {
-		return 'Not a valid data type or string: ' + val;
+		return new Problem(`Not a valid data type or string: ${val}`);
 	}
+	return null;
+}
+
+/**
+ * Validate platform listing
+ * @param {*} platforms possible number
+ * @returns {null|Problem} possible Problem if not valid
+ */
+function validatePlatforms(platforms) {
+	if (!Array.isArray(platforms)) {
+		return new Problem(`must be an array of valid platform names`);
+	}
+
+	if (platforms.length === 0) {
+		return new Problem('array must not be empty. Remove to fall back to "default" platforms based on "since" value; or remove doc entry if this applies to no platforms.');
+	}
+
+	// Filter the platforms against common.VALID_PLATFORMS - any remaining are invalid
+	const remaining = platforms.filter(p => !common.VALID_PLATFORMS.includes(p));
+	if (remaining && remaining.length !== 0) {
+		return new Problem(`Invalid platform name(s): ${remaining}`);
+	}
+
+	return null;
+}
+
+/**
+ * Validate availability
+ * @param {*} availability possible availability
+ * @returns {null|Problem} possible Problem if not valid
+ */
+function validateAvailability(availability) {
+	return validateOneOf(AVAILABILITY, availability);
+}
+
+function validateOneOf(possibilities, value) {
+	if (!possibilities.includes(value)) {
+		return new Problem(`must be one of: ${possibilities}. was: ${value}`)
+	}
+	return null;
+}
+
+/**
+ * Validate permission value
+ * @param {string} permission possible permission
+ * @param {string} propertyName name of the property whose permissions is being set
+ * @returns {null|Problem} possible Problem if not valid
+ */
+function validatePermission(permission, propertyName) {
+	const possibleProblem = validateOneOf(PERMISSIONS, permission);
+	if (possibleProblem) {
+		return possibleProblem;
+	}
+	// It's one of our enumerated values, but if it looks like a constant, should probably be 'read-only'
+	// consider UPPER(_MORE)* style constants (i.e. can't start/end with underscores)
+	if (/^[A-Z]+(_[A-Z]+)*$/.test(propertyName) && permission !== 'read-only') {
+		return new Problem(`property name is all caps so permissions should likely be read-only (was ${permission})`, WARNING); 
+	}
+	return null;
 }
 
 /**
  * Validate number
- * @param {object} number possible number
- * @returns {string} error string if not a number
+ * @param {*} number possible number
+ * @returns {null|Problem} possible Problem if not a number
  */
 function validateNumber(number) {
 	if (typeof number !== 'number') {
-		return 'Not a number value: ' + number;
+		return new Problem(`Not a number value: ${number}`);
 	}
+	return null;
 }
 
 /**
  * Validate OS version
  * @param {object} oses map of os names to versions
- * @returns {string[]} array of error strings
+ * @returns {Problem[]} possible problems (may be empty)
  */
 function validateOSVersions(oses) {
-	let errors = [];
+	const problems = [];
 	for (const key in oses) {
 		if (~common.VALID_OSES.indexOf(key)) {
 			for (const x in oses[key]) {
-				let err;
 				switch (x) {
-					case 'max' :
-					case 'min' :
-						if ((err = validateVersion(oses[key][x]))) {
-							errors.push(err);
+					case 'max':
+					case 'min':
+						const possibleVersionProblem = validateVersion(oses[key][x]);
+						if (possibleVersionProblem) {
+							problems.push(possibleVersionProblem);
 						}
 						break;
 					case 'versions':
-						oses[key][x].forEach(function (elem) {
-							if ((err = validateVersion(elem))) {
-								errors.push(err);
+						// eslint-disable-next-line no-loop-func
+						oses[key][x].forEach(elem => {
+							const possibleVersionProblem = validateVersion(elem);
+							if (possibleVersionProblem) {
+								problems.push(possibleVersionProblem);
 							}
 						});
 						break;
 					default:
-						errors.push('Unknown key: ' + x);
+						problems.push(new Problem(`Unknown key: ${x}`));
 				}
 			}
-
 		} else {
-			errors.push('Invalid OS: ' + key + '; valid OSes are: ' + common.VALID_OSES);
+			problems.push(new Problem(`Invalid OS: ${key}; valid OSes are: ${common.VALID_OSES}`));
 		}
 	}
-	return errors;
+	return problems;
 }
 
 /**
  * Validate primitive
  * @param {object|number|boolean|string} x possible primitive value
- * @return {string} error string if not a primitive
+ * @return {null|Problem} possible Problem if not a primitive
  */
 function validatePrimitive(x) {
 	if (validateBoolean(x) && validateNumber(x) && validateString(x)) {
-		return 'Not a primitive value (Boolean, Number, String): ' + x;
+		return new Problem(`Not a primitive value (Boolean, Number, String): ${x}`);
 	}
+	return null;
 }
 
 /**
@@ -400,36 +559,38 @@ function validatePrimitive(x) {
  * @param {object} [ret.type] return type
  * @param {object} [ret.summary] summary of value
  * @param {object} [ret.constants] possible constant values
- * @returns {string[]} error strings
+ * @returns {Problem[]} problems (may be empty)
  */
 function validateReturns(ret) {
-	var errors = [];
+	const errors = [];
 	if (Array.isArray(ret)) {
-		ret.forEach(function (elem) {
-			errors = errors.concat(validateReturns(elem));
-		});
+		errors.push(new Problem('Replace array of returns with single returns value with type having array of type names', WARNING));
+		ret.forEach(elem => errors.push(...validateReturns(elem)));
 	} else {
-		let err;
+		let sawType = false;
 		for (const key in ret) {
 			switch (key) {
-				case 'type' :
-					if ((err = validateDataType(ret[key])) && ret[key] !== 'void') {
-						errors.push(err);
+				case 'type':
+					if (ret[key] !== 'void') {
+						errors.push(...validateDataType(ret['type']));
+					}
+					sawType = true;
+					break;
+				case 'summary':
+					const possibleProblem = validateString(ret['summary']);
+					if (possibleProblem) {
+						errors.push(possibleProblem);
 					}
 					break;
-				case 'summary' :
-					if ((err = validateString(ret[key]))) {
-						errors.push(err);
-					}
+				case 'constants':
+					errors.push(...validateConstants(ret['constants']));
 					break;
-				case 'constants' :
-					if ((err = validateConstants(ret[key]))) {
-						errors.push(err);
-					}
-					break;
-				default :
-					errors.push('Invalid key: ' + key);
+				default:
+					errors.push(new Problem(`Invalid key: ${key}`));
 			}
+		}
+		if (!sawType) {
+			errors.push(new Problem('Missing "type" for returns'));
 		}
 	}
 	return errors;
@@ -438,58 +599,67 @@ function validateReturns(ret) {
 /**
  * Validate since version
  * @param {object|string} version object holding platform/os to version string; or a normal version string
- * @returns {string[]} array of error strings
+ * @returns {Problem[]} array of Problems (may be empty)
  */
 function validateSince(version) {
+	const errors = [];
+	// since values may be listed per-platform
 	if (typeof version === 'object') {
-		let errors = [];
 		for (const platform in version) {
 			if (platform in common.DEFAULT_VERSIONS) {
 				try {
+					// is it reporting a version before our initial version of the platform?
 					if (nodeappc.version.lt(version[platform], common.DEFAULT_VERSIONS[platform])) {
-						errors.push('Minimum version for ' + platform + ' is ' + common.DEFAULT_VERSIONS[platform]);
+						errors.push(new Problem(`Minimum version for ${platform} is ${common.DEFAULT_VERSIONS[platform]}`));
 					}
 				} catch (e) {
-					errors.push('Invalid version string:' + version[platform]);
+					// it reported an invalid version (unparseable as a version)
+					errors.push(new Problem(`Invalid version string: ${version[platform]}`));
 				}
 			} else {
-				errors.push('Invalid platform: ' + platform);
+				// platform doesn't exist(!) - maybe a typo?
+				errors.push(new Problem(`Invalid platform: ${platform}`));
 			}
 		}
 		return errors;
 	}
-	return validateVersion(version);
+	const possibleProblem = validateVersion(version);
+	if (possibleProblem) {
+		errors.push(possibleProblem);
+	}
+	return errors;
 }
 
 /**
  * Validate string
- * @param {string|object|number} str possible string value
- * @returns {string} error string if value isn't a string
+ * @param {*} str possible string value
+ * @returns {null|Problem} possible Problem if value isn't a string or contains non-ASCII characters
  */
 function validateString(str) {
 	if (typeof str !== 'string') {
-		return 'Not a string value: ' + str;
+		return new Problem(`Not a string value: ${str}`);
 	}
 	if (!/^[\x00-\x7F]*$/.test(str)) { // eslint-disable-line no-control-regex
-		return 'String contains non-ASCII characters.';
+		return new Problem('String contains non-ASCII characters.');
 	}
+	return null;
 }
 
 /**
  * Validate markdown
  * @param {string} str possible markdown string
- * @returns {string} error string if not valid markdown
+ * @returns {null|Problem} possible Problem if not valid markdown (or string!)
  */
 function validateMarkdown(str) {
-	const stringResult = validateString(str);
-	if (stringResult) {
-		return stringResult;
+	const stringProblem = validateString(str);
+	if (stringProblem) {
+		return stringProblem;
 	}
 
 	try {
 		common.markdownToHTML(str);
 	} catch (e) {
-		return 'Error parsing markdown block "' + str + '": ' + e;
+		return new Problem(`Error parsing markdown block "${str}": ${e}`);
 	}
 	return null;
 }
@@ -497,37 +667,71 @@ function validateMarkdown(str) {
 /**
  * Validate version
  * @param {string} version possible version string
- * @return {string} error string if not a value version string
+ * @return {null|Problem} possible Problem if not a value version string
  */
 function validateVersion(version) {
 	try {
 		nodeappc.version.lt('0.0.1', version);
 	} catch (e) {
-		return 'Invalid version: ' + version;
+		return new Problem(`Invalid version: ${version}`);
 	}
+	return null;
+}
+
+/**
+ * adds the contents of the second map to the first (merging values with shared keys)
+ * @param {Map<String, Problem[]>} map1 map getting modified by having another map merged into it
+ * @param {Map<String, Problem[]>} map2 map to combine with the first
+ * @returns {Map<String, Problem[]>}
+ */
+function mergeMaps(map1, map2) {
+	if (map2 === null || map2 === undefined || map2.size < 1) {
+		return map1;
+	}
+
+	map2.forEach((val, key) => {
+		if (map1.has(key)) {
+			// need to merge the results
+			const combined = map1.get(key).concat(val);
+			map1.set(key, combined);
+		} else {
+			map1.set(key, val);
+		}
+	});
+	return map1;
+}
+
+/**
+ * @param {string|null} baseNamespace may be null, may be a dotted namespace
+ * @param {string} keyName base name of the key we're working on
+ */
+function generateFullPath(baseNamespace, keyName) {
+	if (baseNamespace) {
+		return `${baseNamespace}.${keyName}`;
+	}
+	return keyName;
 }
 
 /**
  * Validates an object against a syntax dictionary
- * @param {Object} obj Object to validate
+ * @param {Object} obj Object (from the parsed apidocs) to validate
  * @param {Object} syntax Dictionary defining the syntax
- * @param {string} type type name?
+ * @param {string} type type name? the current key from apidocs?
  * @param {string} currentKey current key
  * @param {string} className Name of class being validated
- * @returns {Object} Syntax errors
+ * @param {string} fullKeyPath full namespace of the key
+ * @returns {Map<String, Problem[]>} mapping from keys to array of problems found for that key
  */
-function validateObjectAgainstSyntax(obj, syntax, type, currentKey, className) {
+function validateObjectAgainstSyntax(obj, syntax, type, currentKey, className, fullKeyPath) {
 	// If syntax is a dictionary, validate object against syntax dictionary
-	let errors = {},
-		err = '';
-	const requiredKeys = syntax.required,
-		optionalKeys = syntax.optional;
+	let result = new Map();
+
 	// Ensure required keys exist and then validate them
+	const requiredKeys = syntax.required;
 	for (const requiredKey in requiredKeys) {
+		const fullRequiredKeyPath = generateFullPath(fullKeyPath, requiredKey);
 		if (requiredKey in obj) {
-			if ((err = validateKey(obj[requiredKey], requiredKeys[requiredKey], requiredKey, className))) {
-				errors[requiredKey] = err;
-			}
+			result = mergeMaps(result, validateKey(obj[requiredKey], requiredKeys[requiredKey], requiredKey, className, fullRequiredKeyPath));
 		} else {
 			// We're missing a required field. Check the parent to see if it's filled in there.
 			// Only do this check when we're overriding an event, property or method, not top-level fields like 'summary'
@@ -551,28 +755,67 @@ function validateObjectAgainstSyntax(obj, syntax, type, currentKey, className) {
 			}
 
 			if (!parentValue) {
-				errors[requiredKey] = 'Required property "' + requiredKey + '" not found';
+				result.set(fullRequiredKeyPath, [ new Problem(`Required property "${requiredKey}" not found`) ]);
 			}
 		}
 	}
+
 	// Validate optional keys if they're on the object
+	const optionalKeys = syntax.optional;
 	for (const optionalKey in optionalKeys) {
 		if (optionalKey in obj) {
-			if ((err = validateKey(obj[optionalKey], optionalKeys[optionalKey], optionalKey, className))) {
-				errors[optionalKey] = err;
-			}
+			result = mergeMaps(result, validateKey(obj[optionalKey], optionalKeys[optionalKey], optionalKey, className, generateFullPath(fullKeyPath, optionalKey)));
 		}
 	}
+
 	// Find keys on obj that aren't required or optional!
 	for (const possiblyInvalidKey in obj) {
 		// If doesn't start with underscores, and isn't required or optional...
 		const isRequired = requiredKeys ? (possiblyInvalidKey in requiredKeys) : false;
 		const isOptional = optionalKeys ? (possiblyInvalidKey in optionalKeys) : false;
 		if (possiblyInvalidKey.indexOf('__') !== 0 && !isRequired && !isOptional) {
-			errors[possiblyInvalidKey] = 'Invalid key(s) in ' + className + ': ' + possiblyInvalidKey;
+			// We found some entry in our docs that isn't required or optional in our syntax definition
+			// so it's probably extraneous (or a typo)
+			result.set(generateFullPath(fullKeyPath, possiblyInvalidKey), [ new Problem(`Invalid key(s) in ${className}: ${possiblyInvalidKey}`) ]);
 		}
 	}
-	return errors;
+	return result;
+}
+
+/**
+ * @param {string} key map key
+ * @param {null|Problem} possibleProblem possible problem
+ * @returns {Map<string, Problem[]>}
+ */
+function possibleProblemAsMap(key, possibleProblem) {
+	const map = new Map();
+	if (possibleProblem) {
+		map.set(key, [ possibleProblem ]);
+	}
+	return map;
+}
+
+/**
+ * @param {string} key map key
+ * @param {Problem[]} possibleProblems possible problems
+ * @returns {Map<string, Problem[]>}
+ */
+function possibleProblemArrayAsMap(key, possibleProblems) {
+	const map = new Map();
+	if (possibleProblems && possibleProblems.length > 0) {
+		map.set(key, possibleProblems);
+	}
+	return map;
+}
+
+/**
+ * @param {string} fullKeyPath something like 'properties[propName].permission' is expected
+ * @returns {string} returns 'propName' in the example
+ */
+function getPropertyName(fullKeyPath) {
+	const lastOpenBracketIndex = fullKeyPath.lastIndexOf('[');
+	const lastCloseBracketIndex = fullKeyPath.lastIndexOf(']');
+	return fullKeyPath.slice(lastOpenBracketIndex + 1, lastCloseBracketIndex);
 }
 
 /**
@@ -581,189 +824,119 @@ function validateObjectAgainstSyntax(obj, syntax, type, currentKey, className) {
  * @param {Object} syntax Dictionary defining the syntax
  * @param {String} currentKey Current key being validated
  * @param {String} className Name of class being validated
- * @returns {Object} Syntax errors, string key to error string as value
+ * @param {string} fullKeyPath full namespace of the current key
+ * @returns {Map<String, Problem[]>} keys are the key paths, values are an array of Problems found for that specific apidoc tree member
  */
-function validateKey(obj, syntax, currentKey, className) {
-	var errors = {},
-		err = '';
-
+function validateKey(obj, syntax, currentKey, className, fullKeyPath) {
+	// if a value is an Array in the syntax definition, it basically means that the given element can have 0+ instances of the wrapped object/syntax
 	if (Array.isArray(syntax)) {
-		if (syntax.length === 1) {
-			if (Array.isArray(syntax[0])) {
-				// Validate array elements against syntax array
-				const errs = [];
-				// If key is 'platforms', validate not an empty array!
-				if (currentKey === 'platforms' && obj.length === 0) {
-					errs.push('platforms array must not be empty. Remove to fall back to "default" platforms based on "since" value; or remove doc entry if this applies to no platforms.');
-				} else {
-					obj.forEach(function (elem) {
-						if (!~syntax[0].indexOf(elem)) {
-							errs.push('Invalid array element: ' + elem + '; possible values: ' + syntax[0]);
-						}
-					});
-				}
-				if (errs.length > 0) {
-					errors = errs;
-				}
-			} else {
-				// Validate each object against the syntax
-				obj.forEach(function (elem) {
-					const name = elem.name || '__noname',
-						errs = validateObjectAgainstSyntax(elem, syntax[0], currentKey, name, className);
-					errors[name] = errs;
-				});
-			}
-		// Validate object value against syntax array
-		} else if (!~syntax.indexOf(obj)) {
-			errors = 'Invalid array element: ' + obj + '; possible values: ' + syntax;
+		if (syntax.length !== 1) {
+			// if the array has more than one entry, the syntax definition is busted
+			return possibleProblemAsMap(fullKeyPath, new Problem(`Syntax tree definition has more than one Array element at ${syntax}. Please fix it.`));
 		}
-	} else if (typeof syntax === 'object') {
-		errors = validateObjectAgainstSyntax(obj, syntax, null, currentKey, className);
-	} else {
-		// Else we have a specific syntax element to validate against
-		switch (syntax) {
-			case 'Boolean' :
-				if ((err = validateBoolean(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Class' :
-				if ((err = validateClass(obj))) {
-					if (standaloneFlag) {
-						console.warn('WARNING! Cannot validate class: %s'.yellow, obj);
-					} else if (!whitelist.includes(obj)) { // only if not whitelisted
-						errors[currentKey] = err;
-					}
-				}
-				break;
-			case 'Constants' :
-				if ((err = validateConstants(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'DataType' :
-				if ((err = validateDataType(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Default':
-				if ((err = validateDefault(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Number':
-				if ((err = validateNumber(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'OSVersions':
-				if ((err = validateOSVersions(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Primitive':
-				if ((err = validatePrimitive(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Returns':
-				if ((err = validateReturns(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Since' :
-				if ((err = validateSince(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'String' :
-				if ((err = validateString(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Markdown' :
-				if ((err = validateMarkdown(obj))) {
-					errors[currentKey] = err;
-				}
-				break;
-			case 'Invalid' :
-				errors[currentKey] = 'Invalid field "' + currentKey + '"';
-				break;
-			default:
-				if (syntax.indexOf('Array') === 0) {
-					switch (syntax.slice(syntax.indexOf('<') + 1, syntax.indexOf('>'))) {
-						case 'events.name' :
-							if ((err = validateAPINames(obj, 'events', className))) {
-								errors[currentKey] = err;
-							}
-							break;
-						case 'methods.name' :
-							if ((err = validateAPINames(obj, 'methods', className))) {
-								errors[currentKey] = err;
-							}
-							break;
-						case 'properties.name' :
-							if ((err = validateAPINames(obj, 'properties', className))) {
-								errors[currentKey] = err;
-							}
-							break;
-						default :
-							console.warn('WARNING! Did not validate: %s = %s'.yellow, currentKey, obj);
-					}
-				} else {
-					console.warn('WARNING! Did not validate: %s = %s'.yellow, currentKey, obj);
-				}
-				break;
-		}
-	}
-	return errors;
-}
 
-/**
- * Add padding for log output
- * @param {number} level log indent level
- * @returns {string} padding string given indent level
- */
-function addPadding(level) {
-	let padding = '';
-	for (let i = 0; i < level; i++) {
-		padding += '	';
+		// Should only contain one enrty, an object holding the definition of elements allowed in the array for this key
+		const firstSyntaxElement = syntax[0];
+		if (typeof firstSyntaxElement !== 'object') {
+			return possibleProblemAsMap(fullKeyPath, new Problem(`Syntax tree definition has a non-Object Array element at ${syntax}. Please fix it.`));
+		}
+
+		// Ok so this element defines how the entries for the key's array should look (i.e. how a given single property, method, event or example are defined)
+		// obj here should be an array!
+		if (!Array.isArray(obj)) {
+			return possibleProblemAsMap(fullKeyPath, new Problem(`We expect an Array of values for ${currentKey}, but received non-Array: ${obj}`));
+		}
+
+		// Validate each object against the syntax
+		let problemMap = new Map();
+		obj.forEach((elem, index) => {
+			const name = elem.name || '__noname';
+			const nameOrIndex = elem.name || index;
+			problemMap = mergeMaps(problemMap, validateObjectAgainstSyntax(elem, firstSyntaxElement, currentKey, name, className, `${fullKeyPath}[${nameOrIndex}]`));
+		});
+		return problemMap;
 	}
-	return padding;
+
+	// we're matching a given parsed apidoc tree item/node against the defined syntax tree/object (defined at the top of this file)
+	if (typeof syntax === 'object') {
+		return validateObjectAgainstSyntax(obj, syntax, null, currentKey, className, fullKeyPath);
+	}
+
+	// We have a specific syntax element to validate against
+	switch (syntax) {
+		case 'Boolean':
+			return possibleProblemAsMap(fullKeyPath, validateBoolean(obj));
+		case 'Class':
+			return possibleProblemAsMap(fullKeyPath, validateClass(obj));
+		case 'Constants':
+			return possibleProblemArrayAsMap(fullKeyPath, validateConstants(obj));
+		case 'DataType':
+			return possibleProblemArrayAsMap(fullKeyPath, validateDataType(obj));
+		case 'Default':
+			return possibleProblemAsMap(fullKeyPath, validateDefault(obj));
+		case 'Number':
+			return possibleProblemAsMap(fullKeyPath, validateNumber(obj));
+		case 'OSVersions':
+			return possibleProblemArrayAsMap(fullKeyPath, validateOSVersions(obj));
+		case 'Primitive':
+			return possibleProblemAsMap(fullKeyPath, validatePrimitive(obj));
+		case 'Returns':
+			return possibleProblemArrayAsMap(fullKeyPath, validateReturns(obj));
+		case 'Since':
+			return possibleProblemArrayAsMap(fullKeyPath, validateSince(obj));
+		case 'String':
+			return possibleProblemAsMap(fullKeyPath, validateString(obj));
+		case 'Markdown':
+			return possibleProblemAsMap(fullKeyPath, validateMarkdown(obj));
+		case 'Platforms':
+			return possibleProblemAsMap(fullKeyPath, validatePlatforms(obj));
+		case 'Availability':
+			return possibleProblemAsMap(fullKeyPath, validateAvailability(obj));
+		case 'Permission':
+			// permissions are always under a given property (only place they are used), so hack
+			// to extract the name of the property
+			const propertyName = getPropertyName(fullKeyPath);
+			return possibleProblemAsMap(fullKeyPath, validatePermission(obj, propertyName));
+		case 'Invalid':
+			return possibleProblemAsMap(fullKeyPath, new Problem(`Invalid field "${currentKey}"`));
+		default:
+			// we use Array<events.name>, Array<methods.name>, or Array<properties.name> in references for the excludes property
+			// so let's validate that the references names actually exist on the type hierarchy
+			if (syntax.indexOf('Array') === 0) {
+				// Pull out the internal "type" of the array reference
+				const baseTypeReference = syntax.slice(syntax.indexOf('<') + 1, syntax.indexOf('>')); 
+				switch (baseTypeReference) {
+					case 'events.name':
+						return possibleProblemAsMap(fullKeyPath, validateAPINames(obj, 'events', className));
+					case 'methods.name':
+						return possibleProblemAsMap(fullKeyPath, validateAPINames(obj, 'methods', className));
+					case 'properties.name':
+						return possibleProblemAsMap(fullKeyPath, validateAPINames(obj, 'properties', className));
+					default:
+						return possibleProblemAsMap(fullKeyPath, new Problem(`Did not validate: ${currentKey} = ${obj}`, WARNING));
+				}
+			}
+			// This should never happen!
+			return possibleProblemAsMap(fullKeyPath, new Problem(`Did not validate: ${currentKey} = ${obj}`, WARNING));
+	}
 }
 
 /**
  * Format and output errors
- * @param {Array} errors array of error stringResult
- * @param {number} level logi indent level?
+ * @param {Map<String, Problem[]>} keysToProblems mapping from key paths to the array of problems found there
  * @return {string} error output
  */
-function outputErrors(errors, level) {
+function outputErrors(keysToProblems) {
 	let errorOutput = '';
-	for (const key in errors) {
-		let error = errors[key];
-		if (error.length > 0 || error !== null) {
-			if (Array.isArray(error)) {
-				error.forEach(function (err) { // eslint-disable-line no-loop-func
-					if (err.length === 0) {
-						return;
-					}
-					if (typeof err === 'object') {
-						err = outputErrors(err, level + 1);
-					}
-					errorOutput += addPadding(level) + err + '\n';
-					errorCount++;
-				});
-			} else if (typeof error === 'object') {
-				if ((error = outputErrors(error, level + 1))) {
-					errorOutput += addPadding(level) + key + '\n' + error;
-				}
-			} else {
-				errorOutput += addPadding(level) + error + '\n';
+	keysToProblems.forEach((problems, key) => {
+		problems.forEach(p => {
+			if (p.isError()) {
 				errorCount++;
 			}
-		}
-	}
+			errorOutput += `${key} - ${p}\n`;
+		});
+	});
+
 	return errorOutput;
 }
 
@@ -843,45 +1016,69 @@ if (Object.keys(doc).length === 0) {
 
 common.createMarkdown(doc);
 
-// FIXME This needs to handle type hierarchy. If a method/property/event overrides a parent, then the parent may have "filled out" a required field/value!
-
+// Keep track of all errors/warnings across all files
+let totalErrorCount = 0;
+let totalWarningCount = 0;
 // Validate YAML
 for (const key in doc) {
-	const cls = doc[key],
-		currentFile = cls.__file;
-	let currentErrors = errorCount,
-		errors = '',
-		diff = 0;
+	const cls = doc[key];
+	const currentFile = cls.__file;
 
+	let errorCount = 0;
+	let warningCount = 0;
+	let output = '';
 	try {
-		errors = outputErrors(validateKey(cls, validSyntax, null, key), 1);
+		const keysToProblems = validateKey(cls, validSyntax, null, key, null);
+		keysToProblems.forEach((problems, key) => {
+			problems.forEach(p => {
+				if (p.isError()) {
+					errorCount++;
+					output += `\t${key} - ${p}\n`.red;
+				} else if (p.isWarning()) {
+					warningCount++;
+					output += `\t${key} - ${p}\n`.yellow;
+				} else {
+					output += `\t${key} - ${p}\n`;
+				}
+			});
+		});
 	} catch (e) {
-		common.log(common.LOG_ERROR, 'PARSING ERROR:\n%s\n%s', currentFile, e);
+		console.log(currentFile);
+		common.log(common.LOG_ERROR, 'PARSING ERROR:\n%s', e);
 		console.error(e.stack);
 		errorCount++;
 	}
 
-	if ((diff = errorCount - currentErrors) > 0) {
-		common.log(common.LOG_ERROR, '%s\n%s: found %s error(s)!\n%s', currentFile, cls.name, diff, errors);
-		currentErrors = errorCount;
-	} else {
-		common.log(common.LOG_INFO, '%s: OK!', cls.name);
+	if (errorCount > 0) {
+		console.log(currentFile);
+		common.log(common.LOG_ERROR, '%s: found %s error(s), %s warning(s)!', cls.name, errorCount, warningCount);
+		console.log(output);
+	} else if (warningCount > 0) {
+		console.log(currentFile);
+		common.log(common.LOG_WARN, '%s: found %s warning(s)!', cls.name, warningCount);
+		console.log(output);
 	}
+	// Sum up all errors/warnings
+	totalErrorCount += errorCount;
+	totalWarningCount += warningCount;
 }
 
-// Exit with error if we found errors or handled exceptions
-if (parseErrors.length + errorCount > 0) {
-	if (errorCount > 0) {
-		common.log(common.LOG_ERROR, 'Found %s error(s)!', errorCount);
-	}
-	// Output exceptions while parsing YAML files
-	if (parseErrors.length > 0) {
-		common.log(common.LOG_ERROR, 'The following files have YAML syntax errors: ');
-		parseErrors.forEach(function (error) {
-			common.log(common.LOG_ERROR, '%s\n%s', error.__file, error);
-		});
-	}
-	process.exit(1);
+// Summarize all errors/warnings
+let exitCode = 0; // Exit with error if we found errors or handled exceptions
+if (parseErrors && parseErrors.length > 0) {
+	common.log(common.LOG_ERROR, 'The following files have YAML syntax errors: ');
+	parseErrors.forEach(function (error) {
+		common.log(common.LOG_ERROR, '%s\n%s', error.__file, error);
+	});
+	exitCode = 1;
+}
+
+if (totalErrorCount > 0) {
+	common.log(common.LOG_ERROR, 'Found %s error(s), %s warning(s)!', totalErrorCount, totalWarningCount);
+	exitCode = 1;
+} else if (totalWarningCount > 0) {
+	common.log(common.LOG_WARN, 'Found %s warning(s)!', totalWarningCount);
 } else {
 	common.log('No errors found!');
 }
+process.exit(exitCode);

--- a/packages/titanium-docgen/validate.js
+++ b/packages/titanium-docgen/validate.js
@@ -401,9 +401,9 @@ function validateDataType(type, fullTypeContext) {
 	}
 
 	// Warn about generic Dictonary/Object types
-	if (['Dictionary', 'Object'].includes(type)) {
+	if ([ 'Dictionary', 'Object' ].includes(type)) {
 		// TODO: How can we mark/skip the valid cases here? Some APIs really do need to say "Object" as the arg/return value
-		return [ new Problem(`Please define a new type rather than using the generic Object/Dictionary references: ${fullTypeContext ? fullTypeContext : type}`, WARNING) ];
+		return [ new Problem(`Please define a new type rather than using the generic Object/Dictionary references: ${fullTypeContext || type}`, WARNING) ];
 	}
 
 	// Is this a built in Javascript type?
@@ -440,7 +440,7 @@ function validateDefault(val) {
  */
 function validatePlatforms(platforms) {
 	if (!Array.isArray(platforms)) {
-		return new Problem(`must be an array of valid platform names`);
+		return new Problem('must be an array of valid platform names');
 	}
 
 	if (platforms.length === 0) {
@@ -467,7 +467,7 @@ function validateAvailability(availability) {
 
 function validateOneOf(possibilities, value) {
 	if (!possibilities.includes(value)) {
-		return new Problem(`must be one of: ${possibilities}. was: ${value}`)
+		return new Problem(`must be one of: ${possibilities}. was: ${value}`);
 	}
 	return null;
 }
@@ -486,7 +486,7 @@ function validatePermission(permission, propertyName) {
 	// It's one of our enumerated values, but if it looks like a constant, should probably be 'read-only'
 	// consider UPPER(_MORE)* style constants (i.e. can't start/end with underscores)
 	if (/^[A-Z]+(_[A-Z]+)*$/.test(propertyName) && permission !== 'read-only') {
-		return new Problem(`property name is all caps so permissions should likely be read-only (was ${permission})`, WARNING); 
+		return new Problem(`property name is all caps so permissions should likely be read-only (was ${permission})`, WARNING);
 	}
 	return null;
 }
@@ -704,6 +704,7 @@ function mergeMaps(map1, map2) {
 /**
  * @param {string|null} baseNamespace may be null, may be a dotted namespace
  * @param {string} keyName base name of the key we're working on
+ * @returns {string}
  */
 function generateFullPath(baseNamespace, keyName) {
 	if (baseNamespace) {
@@ -904,7 +905,7 @@ function validateKey(obj, syntax, currentKey, className, fullKeyPath) {
 			// so let's validate that the references names actually exist on the type hierarchy
 			if (syntax.indexOf('Array') === 0) {
 				// Pull out the internal "type" of the array reference
-				const baseTypeReference = syntax.slice(syntax.indexOf('<') + 1, syntax.indexOf('>')); 
+				const baseTypeReference = syntax.slice(syntax.indexOf('<') + 1, syntax.indexOf('>'));
 				switch (baseTypeReference) {
 					case 'events.name':
 						return possibleProblemAsMap(fullKeyPath, validateAPINames(obj, 'events', className));
@@ -919,25 +920,6 @@ function validateKey(obj, syntax, currentKey, className, fullKeyPath) {
 			// This should never happen!
 			return possibleProblemAsMap(fullKeyPath, new Problem(`Did not validate: ${currentKey} = ${obj}`, WARNING));
 	}
-}
-
-/**
- * Format and output errors
- * @param {Map<String, Problem[]>} keysToProblems mapping from key paths to the array of problems found there
- * @return {string} error output
- */
-function outputErrors(keysToProblems) {
-	let errorOutput = '';
-	keysToProblems.forEach((problems, key) => {
-		problems.forEach(p => {
-			if (p.isError()) {
-				errorCount++;
-			}
-			errorOutput += `${key} - ${p}\n`;
-		});
-	});
-
-	return errorOutput;
 }
 
 /**


### PR DESCRIPTION
Relates to appcelerator/titanium_mobile#11352

This is a fairly large refactor of the doc validation code. The aim here was to:
- clean up the code
- Move away from gathering strings in a tree-like object structure to gather problems with a message/severity in a flat Map by the full "key"
- Which allowed me to add warning-level "linting" so we can warn without "failing" the validation

Then I added warnings for some new things:
- Using bare Object/Dictionary types. In most cases these are a cop-out from declaring a very simple object type with a handful of properties. This does cause "false positives" which I haven't figured out how to avoid/skip (like eslint ignore markers, maybe we can add yml comments on the line to know to skip?)
- constants named LIKE_THIS that have a permission other than `'read-only'`
- methods with a `returns` whose value is an Array. Typically this was mis-used to define multiple possible return types. But the sub-`type` key can handle an array of values, so I think this was more of a yml misunderstanding we just kept rolling with? The "fix" is to have a single `returns` value with a `type` whose value is the Array of possible return types. (For an example of what would get flagged, see `Ti.DB.ResultSet#field()`)

The first warning I added was one I discussed with @drauggres on his PR(s), and is the biggest issue. For TypeScript and simply for API consumers, we often took the "cheap" way out to define some of the very basic objects we sling around for callbacks/events/return types. Or we were lazy and just stuffed in `Object` rather than the real type name. This leads to a lot of uncertainty or having to deep dive into the notes/examples/summaries to figure out how these Objects are actually shaped. We should be defining them explicitly - which when coupled with TypeScript or smart IDEs can help guide the user on the shape of these Objects.