### PR TITLE
feat(docgen): improve accessors generation. remove in 10.0.0

### DIFF
--- a/packages/titanium-docgen/index.js
+++ b/packages/titanium-docgen/index.js
@@ -312,7 +312,7 @@ function hideAPIMembers(apis, type) {
  * @param {Object} api Property object
  * @param {string} className Name of the class
  * @param {string} deprecate Mark accessors as "deprecated" since (>= 8.0.0)
- * @param {string} remove Mark accessors as "removed" since (>= 9.0.0)
+ * @param {string} remove Mark accessors as "removed" since (>= 10.0.0)
  * @return {*}
  */
 function getDeprecation(getOrSet, api, className, deprecate, remove) {
@@ -347,7 +347,7 @@ function getDeprecation(getOrSet, api, className, deprecate, remove) {
  * @param {String} className Name of the class
  * @param {Array<Object>} methods Array of defined methods on the API
  * @param {string} deprecate Mark accessors as "deprecated" since (>= 8.0.0)
- * @param {string} remove Mark accessors as "removed" since (>= 9.0.0)
+ * @param {string} remove Mark accessors as "removed" since (>= 10.0.0)
  * @returns {Array<Object>} Array of methods
  */
 function generateAccessors(apis, className, methods, deprecate, remove) {
@@ -438,7 +438,7 @@ function getSubtype (api) {
  * Process API class
  * @param {Object} api API object to build (and use as base)
  * @param {string} deprecate Mark accessors as "deprecated" since (>= 8.0.0)
- * @param {string} remove Mark accessors as "removed" since (>= 9.0.0)
+ * @param {string} remove Mark accessors as "removed" since (>= 10.0.0)
  * @return {Object} api
  */
 function processAPIs (api, deprecate, remove) {
@@ -965,8 +965,8 @@ let removeAccessors = '';
 if (nodeappc.version.gte(version, '8.0.0')) {
 	deprecateAccessors = '8.0.0';
 }
-if (nodeappc.version.gte(version, '9.0.0')) {
-	removeAccessors = '9.0.0';
+if (nodeappc.version.gte(version, '10.0.0')) {
+	removeAccessors = '10.0.0';
 }
 
 // Process YAML files

--- a/packages/titanium-docgen/index.js
+++ b/packages/titanium-docgen/index.js
@@ -41,6 +41,7 @@ var common = require('./lib/common.js'),
 	cssFile = '',
 	addOnDocs = [],
 	searchPlatform = null,
+	version = '',
 	argc = 0,
 	path = '',
 	templateStr = '';
@@ -917,12 +918,15 @@ if (basePaths.length === 0) {
 	process.exit(1);
 }
 
-const { version } = require(pathMod.resolve(basePaths[0], '..', 'package.json'));
-if (nodeappc.version.gte(version, '8.0.0')) {
-	accessorsDeprecatedSince = '8.0.0';
-}
-if (nodeappc.version.gte(version, '10.0.0')) {
-	accessorsRemovedSince = '10.0.0';
+const sdkPackageJson = pathMod.resolve(basePaths[0], '..', 'package.json');
+if (fs.existsSync(sdkPackageJson)) {
+	version = require(sdkPackageJson).version;
+	if (nodeappc.version.gte(version, '8.0.0')) {
+		accessorsDeprecatedSince = '8.0.0';
+	}
+	if (nodeappc.version.gte(version, '10.0.0')) {
+		accessorsRemovedSince = '10.0.0';
+	}
 }
 
 // Parse YAML files


### PR DESCRIPTION
- Get `version` from `package.json`
- For >= 8.0.0 mark accessors `deprecated` since `8.0.0`
- For >= ~9.0.0~ 10.0.0 mark accessors `removed` in ~`9.0.0`~ `10.0.0`
- Keep `since` and `notes` for already deprecated APIs
- Use in accessors deprecation descriptor from API for already removed APIs