### PR TITLE
feat(docgen): improve typescript generator

### DIFF
--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -721,11 +721,20 @@ class FunctionNode {
 			return;
 		}
 
+		// FIXME: there is no way to define rest parameter in doc
+
 		// Allow rest parameters on Ti.Filesystem.getFile
 		if (this.definition.__inherits === 'Titanium.Filesystem' && this.definition.name === 'getFile') {
 			this.parameters = [ new VariableNode({ name: 'paths', type: 'Array<string>', rest: true }) ];
 			return;
 		}
+		// Allow rest parameters on Titanium.Database.DB.execute
+		if (this.definition.__inherits === 'Titanium.Database.DB' && this.definition.name === 'execute') {
+			parameters[1].optional = false;
+			parameters[1].rest = true;
+		}
+		// NOTE: we can't do same for Titanium.Database.DB.executeAsync, because:
+		// "TS1014: A rest parameter must be last in a parameter list."
 
 		let hasOptional = false;
 		this.parameters = parameters.map(paramDoc => {

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -718,6 +718,12 @@ class VariableNode {
 			this.type = variableDoc.type;
 		}
 		this.summary = variableDoc.summary ? variableDoc.summary.trim() : '';
+		if (variableDoc.deprecated) {
+			this.summary += '\n@deprecated';
+			if (variableDoc.deprecated.notes) {
+				this.summary += ' ' + variableDoc.deprecated.notes;
+			}
+		}
 		this.isConstant = variableDoc.permission === 'read-only';
 		this.optional = variableDoc.optional;
 		this.rest = variableDoc.rest || false;
@@ -751,6 +757,12 @@ class FunctionNode {
 		this.parameters = [];
 		this.parseParameters(functionDoc.parameters);
 		this.summary = functionDoc.summary ? functionDoc.summary.trim() : '';
+		if (functionDoc.deprecated) {
+			this.summary += '\n@deprecated';
+			if (functionDoc.deprecated.notes) {
+				this.summary += ' ' + functionDoc.deprecated.notes;
+			}
+		}
 		this.optional = functionDoc.optional || false;
 	}
 
@@ -967,9 +979,15 @@ class NamespaceNode extends MemberNode {
 	}
 	init() {
 		const moduleDoc = this.api;
-		this.summary = moduleDoc.summary.trim();
+		this.summary = moduleDoc.summary ? moduleDoc.summary.trim() : '';
 
-		this.removed = moduleDoc.deprecated && moduleDoc.deprecated.removed;
+		if (moduleDoc.deprecated && moduleDoc.deprecated.removed) {
+			this.removed = true;
+			this.summary += '\n@deprecated';
+			if (moduleDoc.deprecated.notes) {
+				this.summary += ' ' + moduleDoc.deprecated.notes;
+			}
+		}
 		if (this.relatedNode) {
 			if ((!this.interfaces.length && !this.namespaces.length && !isConstantsOnlyProxy(moduleDoc)) || this.removed) {
 				this.relatedNode.relatedNode = null;
@@ -1044,11 +1062,12 @@ class InterfaceNode extends MemberNode {
 	}
 	init() {
 		const typeDoc = this.api;
-		if (typeDoc.summary) {
-			this.summary = typeDoc.summary.trim();
-		}
-		if (this.removed && typeDoc.deprecated.notes) {
-			this.summary += '\n' + typeDoc.deprecated.notes;
+		this.summary = typeDoc.summary ? typeDoc.summary.trim() : '';
+		if (typeDoc.deprecated) {
+			this.summary += '\n@deprecated';
+			if (typeDoc.deprecated.notes) {
+				this.summary += ' ' + typeDoc.deprecated.notes;
+			}
 		}
 		if (typeDoc.extends && this.name !== 'Titanium') {
 			this.extends = typeDoc.extends;

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -26,7 +26,7 @@ const knowInterfacesList = [
 	'Global.console'
 ];
 
-const eventsMethodsList = [
+const eventsMethods = [
 	'addEventListener',
 	'removeEventListener',
 	'fireEvent'
@@ -893,7 +893,11 @@ class MemberNode {
 			if (this.fullyQualifiedName === 'Titanium.Proxy' && /LifecycleContainer$/.test(methodDoc.name)) {
 				methodDoc.optional = true;
 			}
-			if (this.proxyEventMap && eventsMethodsList.includes(methodDoc.name)) {
+			const isEventMethod = eventsMethods.includes(methodDoc.name);
+			if (!isEventMethod && methodDoc.__inherits && methodDoc.__inherits !== this.fullyQualifiedName && !this.membersAreStatic) {
+				return;
+			}
+			if (this.proxyEventMap && isEventMethod) {
 				const parameters = [ {
 					name: 'name',
 					optional: false,

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -630,7 +630,7 @@ class GlobalTemplateWriter {
 	 */
 	normalizeParameter(paramNode) {
 		if (paramNode.name === 'default') {
-			paramNode.name = 'default_';
+			paramNode.name = 'defaultValue';
 		} else if (paramNode.name === 'function') {
 			paramNode.name = 'func';
 		}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -147,6 +147,9 @@ class DocsParser {
 			}
 			if ((isInterface || isClass) && !isModules) {
 				processed = true;
+				if (namespaceNode && namespaceNode.fullyQualifiedName === 'Titanium') {
+					return;
+				}
 				const interfaceNode = isClass ? new ClassNode(typeInfo) : new InterfaceNode(typeInfo);
 				if (namespaceNode) {
 					namespaceNode.relatedNode = interfaceNode;

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -329,9 +329,10 @@ class GlobalTemplateWriter {
 		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';
 		this.output += '// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped\n';
-		this.output += '// TypeScript Version: 2.6\n';
+		this.output += '// TypeScript Version: 3.0\n';
 		this.output += '\n';
 		this.output += 'type NonFunctionPropertyNames<T> = {\n';
+		this.output += '  // tslint:disable-next-line:ban-types\n';
 		this.output += '	[K in keyof T]: T[K] extends Function ? never : K\n';
 		this.output += '}[keyof T];\n';
 		this.output += 'type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;\n';
@@ -525,10 +526,13 @@ class GlobalTemplateWriter {
 		if (!node.summary) {
 			return '';
 		}
-		let jsDoc = `${this.indent(nestingLevel)}/**\n`;
-		const summary = node.summary.replace(/\s?\n/g, `\n${this.indent(nestingLevel)} * `);
-		jsDoc += `${this.indent(nestingLevel)} * ${summary}\n`;
-		jsDoc += `${this.indent(nestingLevel)} */\n`;
+		const summary = node.summary.replace(/\s?\n/g, `\n${this.indent(nestingLevel)} * `).trim();
+		let jsDoc = '';
+		if (summary) {
+			jsDoc += `${this.indent(nestingLevel)}/**\n`;
+			jsDoc += `${this.indent(nestingLevel)} * ${summary}\n`;
+			jsDoc += `${this.indent(nestingLevel)} */\n`;
+		}
 		if (node instanceof InterfaceNode && node.name === 'IOStream') {
 			jsDoc += this.indent(nestingLevel) + '// tslint:disable-next-line:interface-name\n';
 		}
@@ -573,6 +577,8 @@ class GlobalTemplateWriter {
 				return subTypes.map(typeName => {
 					if (usageHint === 'parameter') {
 						return `ReadonlyArray<${typeName}>`;
+					} else if (typeName.indexOf('<') !== -1) {
+						return `Array<${typeName}>`;
 					} else {
 						return `${typeName}[]`;
 					}
@@ -730,6 +736,7 @@ class FunctionNode {
 		}
 		// Allow rest parameters on Titanium.Database.DB.execute
 		if (this.definition.__inherits === 'Titanium.Database.DB' && this.definition.name === 'execute') {
+			parameters[1].type = 'any[]';
 			parameters[1].optional = false;
 			parameters[1].rest = true;
 		}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -180,6 +180,11 @@ class DocsParser {
 		const parentNamespaceName = namespaceParts.join('.');
 		let parentNamespace = null;
 		if (!this.tree.hasNamespace(parentNamespaceName)) {
+			if (this.apis[parentNamespaceName]) {
+				parentNamespace = new NamespaceNode(this.apis[parentNamespaceName]);
+				this.tree.registerNamespace(parentNamespaceName, parentNamespace);
+				return parentNamespace;
+			}
 			const namespacePathFromRoot = [];
 			let _parent = this.globalNamespace;
 			namespaceParts.shift();
@@ -584,6 +589,8 @@ class GlobalTemplateWriter {
 		}
 
 		switch (docType) {
+			case 'bool':
+				return 'boolean'; // Windows addon only
 			case 'Boolean':
 			case 'Function':
 			case 'Number':
@@ -986,7 +993,9 @@ class InterfaceNode extends MemberNode {
 	}
 	init() {
 		const typeDoc = this.api;
-		this.summary = typeDoc.summary.trim();
+		if (typeDoc.summary) {
+			this.summary = typeDoc.summary.trim();
+		}
 		if (this.removed && typeDoc.deprecated.notes) {
 			this.summary += '\n' + typeDoc.deprecated.notes;
 		}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -170,13 +170,12 @@ class DocsParser {
 		}
 
 		const parentNamespace = this.findOrCreateNamespace(namespaceParts);
-		const isModules = this.isModulesNamespace(typeInfo);
 		const isInterface = this.isInterface(typeInfo);
 		const isClass = this.isClass(typeInfo);
 		const isNamespace = this.isNamespace(typeInfo);
 		let processed = false;
 		let namespaceNode;
-		if (isNamespace || isModules) {
+		if (isNamespace) {
 			processed = true;
 			if (!this.tree.hasNamespace(typeInfo.name)) {
 				namespaceNode = new NamespaceNode(typeInfo);
@@ -188,7 +187,7 @@ class DocsParser {
 				}
 			}
 		}
-		if ((isInterface || isClass) && !isModules) {
+		if (isInterface || isClass) {
 			processed = true;
 			if (namespaceNode && namespaceNode.fullyQualifiedName === 'Titanium') {
 				return namespaceNode;
@@ -280,10 +279,6 @@ class DocsParser {
 	 */
 	isNamespace(typeInfo) {
 		return (typeInfo.__subtype === 'module' || isConstantsOnlyProxy(typeInfo)) && !forcedInterfaces.includes(typeInfo.name);
-	}
-
-	isModulesNamespace(typeInfo) {
-		return typeInfo.name === 'Modules';
 	}
 }
 

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -57,8 +57,18 @@ function isConstantsOnlyProxy(typeInfo) {
 		return false;
 	}
 
-	const ownMethods = typeInfo.methods.filter(methodDoc => methodDoc.__inherits === typeInfo.name);
-	const ownWritableProperties = typeInfo.properties.filter(propertyDoc => propertyDoc.__inherits === typeInfo.name && propertyDoc.permission !== 'read-only');
+	const ownMethods = typeInfo.methods.filter(methodDoc => {
+		if (methodDoc.__hide) {
+			return false;
+		}
+		return methodDoc.__inherits === typeInfo.name;
+	});
+	const ownWritableProperties = typeInfo.properties.filter(propertyDoc => {
+		if (propertyDoc.__hide) {
+			return false;
+		}
+		return propertyDoc.__inherits === typeInfo.name && propertyDoc.permission !== 'read-only';
+	});
 	const ownReadOnlyProperties = typeInfo.properties.filter(propertyDoc => propertyDoc.__inherits === typeInfo.name && propertyDoc.permission === 'read-only');
 	if (ownMethods.length === 0 && ownReadOnlyProperties.length > 0 && ownWritableProperties.length === 0) {
 		return true;

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -19,7 +19,7 @@ const skipApis = [
 ];
 
 // List of modules that need to be generated as an interface instead of a namespace.
-const knowInterfacesList = [
+const forcedInterfaces = [
 	'Titanium.App.iOS.UserDefaults',
 	'Global.String',
 	'Global.JSON',
@@ -248,7 +248,7 @@ class DocsParser {
 			'pseudo',
 		];
 
-		return validSubtypes.includes(typeInfo.__subtype) || knowInterfacesList.includes(typeInfo.name);
+		return validSubtypes.includes(typeInfo.__subtype) || forcedInterfaces.includes(typeInfo.name);
 	}
 
 	isClass(typeInfo) {
@@ -257,7 +257,7 @@ class DocsParser {
 			'proxy',
 			'view'
 		];
-		return validSubtypes.includes(typeInfo.__subtype) && !knowInterfacesList.includes(typeInfo.name);
+		return validSubtypes.includes(typeInfo.__subtype) && !forcedInterfaces.includes(typeInfo.name);
 	}
 
 	/**
@@ -270,7 +270,7 @@ class DocsParser {
 	 * @return {Boolean} True if the API type is considered a namespace in TypeScript, false if not.
 	 */
 	isNamespace(typeInfo) {
-		return (typeInfo.__subtype === 'module' || isConstantsOnlyProxy(typeInfo)) && !knowInterfacesList.includes(typeInfo.name);
+		return (typeInfo.__subtype === 'module' || isConstantsOnlyProxy(typeInfo)) && !forcedInterfaces.includes(typeInfo.name);
 	}
 
 	isModulesNamespace(typeInfo) {
@@ -470,7 +470,8 @@ class GlobalTemplateWriter {
 			return;
 		}
 		const parent = interfaceNode.extends ? 'extends ' + interfaceNode.extends + ' ' : '';
-		this.output += `${this.indent(nestingLevel)}${interfaceNode.keyWord} ${interfaceNode.name} ${parent}{\n`;
+		const isTopLevelClass = this instanceof ClassNode && nestingLevel === 0 ? 'declare ' : '';
+		this.output += `${this.indent(nestingLevel)}${isTopLevelClass}${interfaceNode.keyWord} ${interfaceNode.name} ${parent}{\n`;
 		if (interfaceNode.properties.length > 0) {
 			interfaceNode.properties.forEach(propertyNode => this.writePropertyNode(propertyNode, nestingLevel + 1));
 		}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -350,7 +350,6 @@ class GlobalTemplateWriter {
 		this.output += '	// tslint:disable-next-line:ban-types\n';
 		this.output += '	[K in keyof T]: T[K] extends Function ? K : never\n';
 		this.output += '}[keyof T];\n';
-		this.output += 'type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;\n';
 		this.output += 'type Dictionary<T> = Partial<_Omit<T, FunctionPropertyNames<Ti.Proxy>>>;';
 		this.output += '\n';
 		this.output += 'interface ProxyEventMap {}\n\n';

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -182,7 +182,7 @@ class DocsParser {
 		const parentNamespaceName = namespaceParts.join('.');
 		let parentNamespace = null;
 		if (!this.tree.hasNamespace(parentNamespaceName)) {
-			let namespacePathFromRoot = [];
+			const namespacePathFromRoot = [];
 			namespaceParts.forEach(namespaceName => {
 				namespacePathFromRoot.push(namespaceName);
 				const subordinateNamespaceName = namespacePathFromRoot.join('.');
@@ -444,7 +444,7 @@ class GlobalTemplateWriter {
 	 */
 	generateJsDoc(node, nestingLevel) {
 		let jsDoc = `${this.indent(nestingLevel)}/**\n`;
-		let summary = node.summary.replace(/\s?\n/g, `\n${this.indent(nestingLevel)} * `);
+		const summary = node.summary.replace(/\s?\n/g, `\n${this.indent(nestingLevel)} * `);
 		jsDoc += `${this.indent(nestingLevel)} * ${summary}\n`;
 		jsDoc += `${this.indent(nestingLevel)} */\n`;
 		if (node instanceof InterfaceNode && node.name === 'IOStream') {
@@ -598,7 +598,7 @@ class FunctionNode {
 		this.name = functionDoc.name;
 		if (functionDoc.returns) {
 			if (Array.isArray(functionDoc.returns)) {
-				this.returnType = functionDoc.returns.map(type =>  type.type);
+				this.returnType = functionDoc.returns.map(type => type.type);
 			} else {
 				this.returnType = functionDoc.returns.type;
 			}
@@ -707,7 +707,7 @@ class MemberNode {
 
 			// Filter out create functions for constant only proxies
 			if (/^create/.test(methodDoc.name)) {
-				const returnType  = methodDoc.returns;
+				const returnType = methodDoc.returns;
 				const returnTypeName = Array.isArray(returnType) ? returnType[0].type : returnType.type;
 				const returnTypeDoc = parser.apis[returnTypeName];
 				if (returnTypeDoc && isConstantsOnlyProxy(returnTypeDoc)) {
@@ -759,7 +759,7 @@ class MemberNode {
 			}
 
 			let parameterOverloads = [];
-			for (let type of parameter.type) {
+			for (const type of parameter.type) {
 				if (dictionaryTypePattern.test(type)) {
 					const anyOverloadDoc = JSON.parse(originalMethodDocJsonString);
 					anyOverloadDoc.parameters[i].type = 'any';

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -955,7 +955,7 @@ class NamespaceNode extends MemberNode {
 
 		this.removed = moduleDoc.deprecated && moduleDoc.deprecated.removed;
 		if (this.relatedNode) {
-			if ((!this.interfaces.length && !this.namespaces.length) || this.removed) {
+			if ((!this.interfaces.length && !this.namespaces.length && !isConstantsOnlyProxy(moduleDoc)) || this.removed) {
 				this.relatedNode.relatedNode = null;
 				return;
 			}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -21,9 +21,7 @@ const skipApis = [
 // List of modules that need to be generated as an interface instead of a namespace.
 const forcedInterfaces = [
 	'Titanium.App.iOS.UserDefaults',
-	'Global.String',
-	'Global.JSON',
-	'Global.console'
+	'Global.String'
 ];
 
 const eventsMethods = [
@@ -494,7 +492,7 @@ class GlobalTemplateWriter {
 	writeVariableNode(variableNode, nestingLevel) {
 		this.output += this.generateJsDoc(variableNode, nestingLevel);
 		const inGlobal = nestingLevel === 0 ? 'declare ' : '';
-		const isConstant = variableNode.isConstant ? 'const' : 'let';
+		const isConstant = variableNode.isConstant ? 'const' : inGlobal ? 'var' : 'let';
 		this.output += `${this.indent(nestingLevel)}${inGlobal}${isConstant} ${variableNode.name}: ${this.normalizeType(variableNode.type)};\n\n`;
 	}
 

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -894,6 +894,9 @@ class MemberNode {
 		const properties = [];
 		this.events.push(baseEvent);
 		events.forEach(eventDoc => {
+			if (eventDoc.deprecated && eventDoc.deprecated.removed) {
+				return;
+			}
 			const eventNode = InterfaceNode.createEvent(eventDoc, this);
 			this.events.push(eventNode);
 			const name = eventDoc.name.indexOf(':') === -1 ? eventDoc.name : `"${eventDoc.name}"`;

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -449,13 +449,12 @@ class GlobalTemplateWriter {
 				this.writeInterfaceNode(eventNode, nestingLevel));
 		}
 		this.output += this.generateJsDoc(interfaceNode, nestingLevel);
-		const inGlobal = nestingLevel === 0 ? 'declare ' : '';
 		if (interfaceNode.removed) {
-			this.output += `${this.indent(nestingLevel)}${inGlobal}const ${interfaceNode.name}: never;\n`;
+			this.output += `${this.indent(nestingLevel)}const ${interfaceNode.name}: never;\n`;
 			return;
 		}
 		const parent = interfaceNode.extends ? 'extends ' + interfaceNode.extends + ' ' : '';
-		this.output += `${this.indent(nestingLevel)}${inGlobal}${interfaceNode.keyWord} ${interfaceNode.name} ${parent}{\n`;
+		this.output += `${this.indent(nestingLevel)}${interfaceNode.keyWord} ${interfaceNode.name} ${parent}{\n`;
 		if (interfaceNode.properties.length > 0) {
 			interfaceNode.properties.forEach(propertyNode => this.writePropertyNode(propertyNode, nestingLevel + 1));
 		}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -998,6 +998,21 @@ class InterfaceNode extends MemberNode {
 			this.parseProperties(typeDoc.properties);
 			this.parseMethods(typeDoc.methods);
 		}
+		// FIXME: Ti.Proxy has no documented "id" property
+		// currently if we put it in docs - accessors methods will show up in
+		// every class extended from Ti.Proxy
+		if (this.fullyQualifiedName === 'Titanium.Proxy') {
+			const array = this.properties.filter(prop => prop.name === 'id');
+			if (!array.length) {
+				// injecting "id" property into "Titanium.Proxy"
+				this.properties.push(new VariableNode({
+					name: 'id',
+					optional: true,
+					summary: 'Proxy identifier',
+					type: 'string | number'
+				}, false));
+			}
+		}
 	}
 
 	filterProperties(propertyDoc) {

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -331,15 +331,17 @@ class GlobalTemplateWriter {
 		this.output += '// Project: https://github.com/appcelerator/titanium_mobile\n';
 		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';
+		this.output += '//                 Sergey Volkov <https://github.com/drauggres>\n';
 		this.output += '// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped\n';
 		this.output += '// TypeScript Version: 3.0\n';
 		this.output += '\n';
-		this.output += 'type NonFunctionPropertyNames<T> = {\n';
-		this.output += '  // tslint:disable-next-line:ban-types\n';
-		this.output += '	[K in keyof T]: T[K] extends Function ? never : K\n';
+		this.output += 'type _Omit<T, K extends keyof any | undefined> = Pick<T, Exclude<keyof T, K>>;\n';
+		this.output += 'type FunctionPropertyNames<T> = {\n';
+		this.output += '	// tslint:disable-next-line:ban-types\n';
+		this.output += '	[K in keyof T]: T[K] extends Function ? K : never\n';
 		this.output += '}[keyof T];\n';
-		this.output += 'type NonFunctionProperties<T> = Pick<T, NonFunctionPropertyNames<T>>;\n';
-		this.output += 'type Dictionary<T> = Partial<NonFunctionProperties<T>>;\n';
+		this.output += 'type FunctionProperties<T> = Pick<T, FunctionPropertyNames<T>>;\n';
+		this.output += 'type Dictionary<T> = Partial<_Omit<T, FunctionPropertyNames<Ti.Proxy>>>;';
 		this.output += '\n';
 		this.output += 'interface ProxyEventMap {}\n\n';
 	}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -514,7 +514,7 @@ class GlobalTemplateWriter {
 		this.output += this.generateJsDoc(functionNode, nestingLevel);
 		const inGlobal = nestingLevel === 0 ? 'declare ' : '';
 		if (functionNode.removed) {
-			this.output += `${this.indent(nestingLevel)}${inGlobal}const ${functionNode.name}: never;\n`;
+			this.output += `${this.indent(nestingLevel)}${inGlobal}const ${functionNode.name}: never;\n\n`;
 			return;
 		}
 		const parametersString = this.prepareParameters(functionNode.parameters);
@@ -532,7 +532,7 @@ class GlobalTemplateWriter {
 		this.output += this.generateJsDoc(functionNode, nestingLevel);
 		const isStatic = functionNode.isStatic ? 'static ' : '';
 		if (functionNode.removed) {
-			this.output += `${this.indent(nestingLevel)}${isStatic}${functionNode.name}: never;\n`;
+			this.output += `${this.indent(nestingLevel)}${isStatic}${functionNode.name}: never;\n\n`;
 			return;
 		}
 		const parametersString = this.prepareParameters(functionNode.parameters);

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../lib/common.js');
+const path = require('path');
 
 /*
  * Map of invalid types and their replacement
@@ -130,6 +131,10 @@ class DocsParser {
 			}
 
 			const typeInfo = this.apis[fullyQualifiedTypeName];
+			if (typeInfo.__file.indexOf(path.join('apidoc', 'Modules')) !== -1) {
+				// skip bundled documentation for modules
+				return;
+			}
 			const namespaceParts = typeInfo.name.split('.');
 			namespaceParts.pop();
 			if (skipApis.includes(typeInfo.name)) {

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -696,11 +696,17 @@ class GlobalTemplateWriter {
 	 */
 	prepareParameterString(paramNode) {
 		this.normalizeParameter(paramNode);
-		let parameter = paramNode.rest ? '...' + paramNode.name : paramNode.name;
-		if (paramNode.optional) {
+		let parameter = paramNode.repeatable ? '...' + paramNode.name : paramNode.name;
+
+		// TS1047: A rest parameter cannot be optional.
+		if (paramNode.optional && !paramNode.repeatable) {
 			parameter += '?';
 		}
-		parameter += `: ${this.normalizeType(paramNode.type, paramNode.rest ? null : 'parameter')}`;
+		let type = this.normalizeType(paramNode.type, paramNode.repeatable ? null : 'parameter');
+		if (paramNode.repeatable && type.indexOf('Array<') !== 0 && type.indexOf('[]') !== type.length - 2) {
+			type = type.indexOf(' | ') !== -1 ? `Array<${type}>` : `${type}[]`;
+		}
+		parameter += `: ${type}`;
 
 		return parameter;
 	}
@@ -729,7 +735,7 @@ class VariableNode {
 		}
 		this.isConstant = variableDoc.permission === 'read-only';
 		this.optional = variableDoc.optional;
-		this.rest = variableDoc.rest || false;
+		this.repeatable = variableDoc.repeatable || false;
 	}
 }
 
@@ -773,22 +779,6 @@ class FunctionNode {
 		if (!parameters) {
 			return;
 		}
-
-		// FIXME: there is no way to define rest parameter in doc
-
-		// Allow rest parameters on Ti.Filesystem.getFile
-		if (this.definition.__inherits === 'Titanium.Filesystem' && this.definition.name === 'getFile') {
-			this.parameters = [ new VariableNode({ name: 'paths', type: 'Array<string>', rest: true }) ];
-			return;
-		}
-		// Allow rest parameters on Titanium.Database.DB.execute
-		if (this.definition.__inherits === 'Titanium.Database.DB' && this.definition.name === 'execute') {
-			parameters[1].type = 'any[]';
-			parameters[1].optional = false;
-			parameters[1].rest = true;
-		}
-		// NOTE: we can't do same for Titanium.Database.DB.executeAsync, because:
-		// "TS1014: A rest parameter must be last in a parameter list."
 
 		let hasOptional = false;
 		this.parameters = parameters.map(paramDoc => {
@@ -942,9 +932,17 @@ class MemberNode {
 				}
 				return;
 			}
-			const node = new FunctionNode(methodDoc, this.membersAreStatic);
-			this.innerNodesMap.set(methodDoc.name, node);
-			this.methods.push(node);
+
+			// Generate overloads if required and add them instead of the original method
+			const overloads = this.generateMethodOverloadsIfRequired(methodDoc);
+			if (!overloads.length) {
+				overloads.push(methodDoc);
+			}
+			overloads.forEach(doc => {
+				const node = new FunctionNode(doc, this.membersAreStatic);
+				this.innerNodesMap.set(doc.name, node);
+				this.methods.push(node);
+			});
 		});
 	}
 
@@ -976,6 +974,62 @@ class MemberNode {
 			summary: ''
 		});
 		this.events.push(this.proxyEventMap);
+	}
+
+	/**
+	 * Generates overload method definitions for methods which have parameter
+	 * definitions that are not compatible with union types.
+	 *
+	 * Currently only handles one case where a parameter can be passed as both a
+	 * single (repeatable) value and as an array, e.g. ...Ti.UI.View[], Array<Ti.UI.View>
+	 *
+	 * @param {Object} methodDoc Method definitions as parsed from YAML files
+	 * @return {Array<Object>} List of overload method definitions
+	 */
+	generateMethodOverloadsIfRequired(methodDoc) {
+		const parameters = methodDoc.parameters;
+		if (!parameters) {
+			return [];
+		}
+
+		// TODO: proper types for Titanium.Database.DB.executeAsync, problem is:
+		// "TS1014: A rest parameter must be last in a parameter list."
+
+		const originalMethodDocJsonString = JSON.stringify(methodDoc);
+		const arrayTypePattern = /Array<.*>/;
+		let methodOverloads = [];
+		let hasRepeatableAndArray = false;
+		const last = parameters.length - 1;
+		const parameter = parameters[last];
+		if (!Array.isArray(parameter.type) || !parameter.repeatable) {
+			return [methodDoc];
+		}
+
+		let parameterOverloads = [];
+		for (const type of parameter.type) {
+			if (arrayTypePattern.test(type)) {
+				hasRepeatableAndArray = true;
+				const arrayOverloadDoc = JSON.parse(originalMethodDocJsonString);
+				arrayOverloadDoc.parameters[last].repeatable = false;
+				arrayOverloadDoc.parameters[last].type = type;
+				parameterOverloads.push(arrayOverloadDoc);
+			} else {
+				const newOverloadDoc = JSON.parse(originalMethodDocJsonString);
+				newOverloadDoc.parameters[last].type = type;
+				newOverloadDoc.parameters[last].optional = false;
+				parameterOverloads.push(newOverloadDoc);
+			}
+		}
+
+		if (hasRepeatableAndArray) {
+			methodOverloads = methodOverloads.concat(parameterOverloads);
+		}
+
+		if (hasRepeatableAndArray) {
+			return methodOverloads;
+		} else {
+			return [JSON.parse(originalMethodDocJsonString)];
+		}
 	}
 }
 

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -829,7 +829,7 @@ class MemberNode {
 	}
 
 	parseProperties(properties) {
-		if (!properties) {
+		if (!properties || !properties.length) {
 			return;
 		}
 
@@ -872,6 +872,10 @@ class MemberNode {
 
 		// Filter out the Ti.App.Android.R accessor as it is represented by a namespace already
 		if (this.fullyQualifiedName === 'Titanium.App.Android' && propertyDoc.name === 'R') {
+			return false;
+		}
+
+		if (propertyDoc.__inherits && propertyDoc.__inherits !== this.fullyQualifiedName && !this.membersAreStatic) {
 			return false;
 		}
 


### PR DESCRIPTION
- [x] Dictionary<T> (typed factory methods):

 ```typescript
 const button = Ti.UI.createButton({
  width: 100,
  backgroundColor: '#ddd',
  text: '+',   // TS2345: [..] 'text' does not exist in type [..]
  left: 10
});
```
- [x] Typed `this` in `addEventListner`, `removeEventListener`:
 ```typescript
const button = Ti.UI.createButton();
button.addEventListener('click', function(e) {
  this.backgroundColor = 'red';
  this.text = 123;  // TS2339: Property 'text' does not exist on type 'Button'.
});
```
- [x] Types for Events:
 ```typescript
const button = Ti.UI.createButton();

// know event type
button.addEventListener('click', function(e) {
  e.source.backgroundColor = 'red';
  console.log(`x: ${e.x}`);
  console.log(`x: ${e.z}`);  // TS2339: Property 'z' does not exist on type 'Button_click_Event'.
});

// unknown event type
button.addEventListener('myEvent', function(e) {
  console.log(e.lol);  // ok, because 'myEvent' is unknown event type -> e: any
});

``` 

- [x]  Modules declared as both `namespace` and `class` (with static methods). This allows to define types for specific events for Modules like `Ti.Geolocation`, `Ti.Media`, `Ti.Network` etc.:
```typescript
Ti.Network.addEventListener('change', e => {
  console.log(e.reason);
  console.log(e.status);  // TS2339: Property 'status' does not exist on type 'Network_change_Event'
});
```

Additonal changes:
1. inject `id?: string|number` in `Ti.Proxy`
2. rest parameter for `Titanium.Database.DB.execute`

Explanations:
1. For every event generated:
- base event interface with name `${ClassName}BaseEvent` (e.g. `ButtonBaseEvent`)
- event interface with name `${ClassName}_${EventName}_Event` (e.g. `Button_click_Event`) and extended from the base event
- "map" interface to math event name and event interface (e.g. `ButtonEventMap`)
- note: `:` in the name of a event is replaced with `_` for generated interfaces (event name itself is not changed)

**IMPORTANT**: event interface name is not documented and is generated as shown above. Since they will be in users code (if they decide to write in TypeScript), they could not be changed at any time. These names will be part of the API and must remain stable.

2. removed `canExtend` + `removeMembers`: were not really useful, only could decrease size of the output, but `removeMembers` did not take in accout `excludes`, so result was incorrect. 
3. removed `generateMethodOverloadsIfRequired`: as was mentioned in the function description:
> Currently only handles one case where a parameter can be passed as both a single value and as an array, e.g. Ti.UI.View, Array<Ti.UI.View>

TypeScript can handle this case e.g. `add(view: Titanium.UI.View | Titanium.UI.View[]): void;`

4. code from nodes constructors moved to the `init` method: since for one module could be generated two nodes (interface and namespace) in order to decrease output size I'm skipping namespace node without any internal interfaces and namespaces. To do this I need at first to build "the tree" and then deside where I want to keep properties and methods/functions.


~Only thing that makes impossible to use generated file to write in TypeScript is [the problem with PickerColumn](https://github.com/appcelerator/titanium_mobile/pull/11348)~

UPD: APIs from files under `apidoc/Modules` are removed from output. It is incorrect to put them inside of `titanium/index.d.ts` (ideally they should be placed in separate files `ti.cloud/index.d.ts` and `ti.cloudpush/index.d.ts`).

More things came up:
- [x] fix `global.console` and `global.JSON` variables (currently they are interfaces) (https://github.com/appcelerator/titanium_mobile/pull/11464)
- [x] fix methods of `global.console` (`log`/`err`/`warn`/`info`/`debug` accepts "vararg") (https://github.com/appcelerator/titanium_mobile/pull/11468)