### PR TITLE
feat: font awesome plugin

### DIFF
--- a/packages/docs/docs/.vuepress/config.js
+++ b/packages/docs/docs/.vuepress/config.js
@@ -73,6 +73,7 @@ module.exports = context => ({
     }],
     // use full name or vuepress tries to load `../../apidocs` folder
     'vuepress-plugin-apidocs',
+    'fontawesome',
     '@vuepress/back-to-top'
   ]
 })
@@ -86,7 +87,8 @@ function getGuideSidebar (groupA, groupB) {
         '',
         'getting-started',
         'versioning',
-        'api-docs'
+        'api-docs',
+        'fontawesome'
       ]
     },
     {
@@ -108,6 +110,7 @@ function getPluginSidebar (pluginTitle, pluginIntro) {
         ['', pluginIntro],
         'versioning-plugin',
         'apidocs-plugin',
+        'fontawesome-plugin'
       ]
     }
   ]

--- a/packages/docs/docs/.vuepress/fa-icons.js
+++ b/packages/docs/docs/.vuepress/fa-icons.js
@@ -1,0 +1,4 @@
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCoffee } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faCoffee)

--- a/packages/docs/docs/guide/fontawesome.md
+++ b/packages/docs/docs/guide/fontawesome.md
@@ -1,0 +1,63 @@
+# FontAwesome
+
+Add FontAwesome icons to your VuePress site. Fully compatible with all free and pro icons thanks to [@fortawesome/vue-fontawesome](https://github.com/FortAwesome/vue-fontawesome).
+
+Out of the box the plugin only installs/registers the `@fortawesome/vue-fontawesome` components and the FontAwesome SVG core library. This gives you full flexibility over the icons you want to use, but requires a little setup upfront.
+
+## Install SVG icons
+
+First you need to install the icons you want to use. For example, let's use the [free solid icons](https://fontawesome.com/icons?d=gallery&s=solid&m=free).
+
+```sh
+yarn add -D @fortawesome/free-solid-svg-icons
+# OR npm i -D @fortawesome/free-solid-svg-icons
+```
+
+::: tip Add more styles or Pro icons
+Follow the instructions in the readme of the `vue-fontawesome` component how to [add more styles or Pro icons](https://github.com/FortAwesome/vue-fontawesome#add-more-styles-or-pro-icons).
+:::
+
+## Import your icons
+
+Now that the required SVG icons are installed they need to be registered with the FontAwesome SVG core library (to take advantage of only bundling the icons you actually use). For this, just create a file named `fa-icons.js` in your `.vuepress` folder and add the following code:
+
+```js
+import { library } from '@fortawesome/fontawesome-svg-core'
+import { faCoffee } from '@fortawesome/free-solid-svg-icons'
+
+library.add(faCoffee)
+```
+
+This will import the :fas-coffee: icon and make it available in all your markdown files.
+
+You can change the file that is used to import all of your icons with the [`iconsFile`](../plugins/fontawesome-plugin#iconsfile) option.
+
+::: tip
+See [Why use the concept of a library?](https://github.com/FortAwesome/vue-fontawesome#why-use-the-concept-of-a-library) for more details and examples on how to import icons.
+:::
+
+## Markdown Shorthand
+
+For quick access in markdown files this plugin adds a special `:<prefix>-<icon>:` syntax. For example to refer to the above coffee icon from the solid icons
+
+```md
+This is the :fas-coffee: icon!
+```
+
+**Example:**
+
+This is the :fas-coffee: icon!
+
+## Vue Component
+
+For more fine grained control over the displayed icon you can use the `@fortawesome/vue-fontawesome` components. For example, the basic `<font-awesome-icon />` component can be used to display the icon and pass additional options:
+
+```md
+<font-awesome-icon :icon="['fas', 'coffee']" size="4x" />
+```
+
+**Example:**
+
+<font-awesome-icon :icon="['fas', 'coffee']" size="4x" />
+
+See the supported [features](https://github.com/FortAwesome/vue-fontawesome#features) of `@fortawesome/vue-fontawesome` for a list of all available compoents and options. All three components are already registered as global components so you can use all basic and advanced features.

--- a/packages/docs/docs/plugins/README.md
+++ b/packages/docs/docs/plugins/README.md
@@ -1,7 +1,7 @@
 # Plugins
 
-The Titanium Docs DevKit currently provides two plugins for VuePress.
+The Titanium Docs DevKit provides a couple of plugins that add new features to VuePress and improve it for usage in technical documentations.
 
-With the [Versioning Plugin](./versioning-plugin.md) you can add versioning features to VuePress. Snapshot the current state of your docs to easily access older revisions at a later time. The [Titanium Theme](../theme/README.md) has full support for the versioning plugin and allows you to switch between the different versions of your site.
-
-The [API Docs Plugin](./apidocs-plugin.md) can be used easily add API docs to a markdown file. These usually are too complex to write directly in markdown, which is where this plugin steps in.
+- [Versioning Plugin](./versioning-plugin.md): Adds versioning features to VuePress. Snapshot the current state of your docs to easily access older revisions at a later time. The [Titanium Theme](../theme/README.md) has full support for the versioning plugin and allows you to switch between the different versions of your site.
+- [API Docs Plugin](./apidocs-plugin.md): Easily add API docs to a markdown file. These usually are too complex to write directly in markdown, which is where this plugin steps in.
+- [FontAwesome Plugin](./fontawesome-plugin.md): Use FontAwesome icons in VuePress. Fully featured with Markdown shorthand and tree-shaking support.

--- a/packages/docs/docs/plugins/fontawesome-plugin.md
+++ b/packages/docs/docs/plugins/fontawesome-plugin.md
@@ -1,0 +1,41 @@
+# FontAwesome Plugin
+
+> Easy integration of FontAwesome icons in your VuePress site
+
+## Installation
+
+```bash
+yarn add -D vuepress-plugin-fontawesome
+# OR npm i -D vuepress-plugin-fontawesome
+```
+
+## Usage
+
+```js
+module.exports = {
+  plugins: ['fontawesome']
+}
+```
+
+### Passing Options
+
+```js
+const path = require('path' );
+
+module.exports = context => ({
+  plugins: [
+    ['fontawesome', {
+      iconFile: path.join(context.sourceDir, '.vuepress', 'my-icons.js')
+    }]
+  ]
+})
+```
+
+## Options
+
+### iconsFile
+
+File used to import and register icons with the FontAwesome SVG core library. This file will be added to the [enhanceAppFiles](https://vuepress.vuejs.org/plugin/option-api.html#enhanceappfiles) option of this plugin.
+
+- Type: `string`
+- Default: `.vuepress/fa-icons.js`

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -13,6 +13,7 @@
     "createVersion": "vuepress version docs"
   },
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^5.13.1",
     "@vuepress/plugin-back-to-top": "1.5.2",
     "fs-extra": "^8.1.0",
     "vuepress": "^1.5.2",

--- a/packages/vuepress/vuepress-plugin-fontawesome/README.md
+++ b/packages/vuepress/vuepress-plugin-fontawesome/README.md
@@ -1,0 +1,5 @@
+# vuepres-plugin-fontawesome
+
+> FontAwesome plugin for VuePress
+
+📖 View the [Documentation](https://titanium-docs-devkit.netlify.com/guide/fontawesome.html).

--- a/packages/vuepress/vuepress-plugin-fontawesome/index.js
+++ b/packages/vuepress/vuepress-plugin-fontawesome/index.js
@@ -1,0 +1,22 @@
+const path = require('path')
+
+const fontAwesomePlugin = require('./lib/markdown')
+
+module.exports = (options, context) => {
+  const iconsFile = options.iconsFile || path.resolve(context.sourceDir, '.vuepress', 'fa-icons.js')
+  return {
+    enhanceAppFiles: [
+      path.resolve(__dirname, 'lib', 'enhance.js'),
+      iconsFile
+    ],
+
+    chainMarkdown (config) {
+      config.plugin('fontawesome')
+        .use(fontAwesomePlugin)
+    },
+
+    chainWebpack (config) {
+      config.resolve.modules.add(path.join(__dirname, 'node_modules'))
+    }
+  }
+}

--- a/packages/vuepress/vuepress-plugin-fontawesome/lib/enhance.js
+++ b/packages/vuepress/vuepress-plugin-fontawesome/lib/enhance.js
@@ -1,0 +1,11 @@
+import {
+  FontAwesomeIcon,
+  FontAwesomeLayers,
+  FontAwesomeLayersText
+} from '@fortawesome/vue-fontawesome'
+
+export default ({ Vue }) => {
+  Vue.component('font-awesome-icon', FontAwesomeIcon)
+  Vue.component('font-awesome-layers', FontAwesomeLayers)
+  Vue.component('font-awesome-layers-text', FontAwesomeLayersText)
+}

--- a/packages/vuepress/vuepress-plugin-fontawesome/lib/markdown.js
+++ b/packages/vuepress/vuepress-plugin-fontawesome/lib/markdown.js
@@ -1,0 +1,82 @@
+/**
+ * MarkdownIt FontAwesome icons plugin, based on the emoji plugin
+ *
+ * @see https://github.com/markdown-it/markdown-it-emoji
+ */
+
+const iconPattern = /\:(fa\w)-([\w\-]+)\:/
+const replacePattern = new RegExp(iconPattern.source, 'g')
+
+module.exports = md => {
+  md.renderer.rules.fontawesome = fontAwesomeRenderer
+  md.core.ruler.push('fontawesome', createFontAwesomeRule(md))
+}
+
+function fontAwesomeRenderer (tokens, idx) {
+  return tokens[idx].content
+}
+
+function createFontAwesomeRule (md) {
+  const arrayReplaceAt = md.utils.arrayReplaceAt
+
+  function splitTextToken (text, level, Token) {
+    let token
+    let lastPosition = 0
+    const nodes = []
+
+    text.replace(replacePattern, function (match, prefix, icon, offset) {
+      // Add new tokens to pending list
+      if (offset > lastPosition) {
+        token = new Token('text', '', 0)
+        token.content = text.slice(lastPosition, offset)
+        nodes.push(token)
+      }
+
+      token = new Token('fontawesome', '', 0)
+      token.markup = icon
+      token.content = `<font-awesome-icon :icon="['${prefix}', '${icon}']" />`
+      nodes.push(token)
+
+      lastPosition = offset + match.length
+    })
+
+    if (lastPosition < text.length) {
+      token = new Token('text', '', 0)
+      token.content = text.slice(lastPosition)
+      nodes.push(token)
+    }
+
+    return nodes
+  }
+
+  return function iconReplace (state) {
+    const blockTokens = state.tokens
+    let autolinkLevel = 0
+
+    for (let j = 0, l = blockTokens.length; j < l; j++) {
+      if (blockTokens[j].type !== 'inline') {
+        continue
+      }
+
+      let tokens = blockTokens[j].children
+      // We scan from the end, to keep position when new tags added.
+      // Use reversed logic in links start/end match
+      for (let i = tokens.length - 1; i >= 0; i--) {
+        const token = tokens[i]
+
+        if (token.type === 'link_open' || token.type === 'link_close') {
+          if (token.info === 'auto') {
+            autolinkLevel -= token.nesting
+          }
+        }
+
+        if (token.type === 'text' && autolinkLevel === 0 && iconPattern.test(token.content)) {
+          // replace current node
+          blockTokens[j].children = tokens = arrayReplaceAt(
+            tokens, i, splitTextToken(token.content, token.level, state.Token)
+          )
+        }
+      }
+    }
+  }
+}

--- a/packages/vuepress/vuepress-plugin-fontawesome/package.json
+++ b/packages/vuepress/vuepress-plugin-fontawesome/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "vuepress-plugin-fontawesome",
+  "version": "0.0.0",
+  "description": "FontAwesome plugin for VuePress",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "vuepress",
+    "fontawesome",
+    "font",
+    "awesome",
+    "icons"
+  ],
+  "author": "Axway Appcelerator",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "directory": "packages/vuepress/vuepress-plugin-fontawesome"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^1.2.29",
+    "@fortawesome/vue-fontawesome": "^0.1.10"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -951,6 +951,30 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@fortawesome/fontawesome-common-types@^0.2.29":
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.29.tgz#e1a456b643237462d390304cab6975ff3fd68397"
+  integrity sha512-cY+QfDTbZ7XVxzx7jxbC98Oxr/zc7R2QpTLqTxqlfyXDrAJjzi/xUIqAUsygELB62JIrbsWxtSRhayKFkGI7MA==
+
+"@fortawesome/fontawesome-svg-core@^1.2.29":
+  version "1.2.29"
+  resolved "https://registry.yarnpkg.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.29.tgz#34ef32824664534f9e4ef37982ebf286b899a189"
+  integrity sha512-xmPmP2t8qrdo8RyKihTkGb09RnZoc+7HFBCnr0/6ZhStdGDSLeEd7ajV181+2W29NWIFfylO13rU+s3fpy3cnA==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/free-solid-svg-icons@^5.13.1":
+  version "5.13.1"
+  resolved "https://registry.yarnpkg.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.13.1.tgz#010a846b718a0f110b3cd137d072639b4e8bd41a"
+  integrity sha512-LQH/0L1p4+rqtoSHa9qFYR84hpuRZKqaQ41cfBQx8b68p21zoWSekTAeA54I/2x9VlCHDLFlG74Nmdg4iTPQOg==
+  dependencies:
+    "@fortawesome/fontawesome-common-types" "^0.2.29"
+
+"@fortawesome/vue-fontawesome@^0.1.10":
+  version "0.1.10"
+  resolved "https://registry.yarnpkg.com/@fortawesome/vue-fontawesome/-/vue-fontawesome-0.1.10.tgz#eeeec1e4e8850bed0468f938292b06cda793bf34"
+  integrity sha512-b2+SLF31h32LSepVcXe+BQ63yvbq5qmTCy4KfFogCYm2bn68H5sDWUnX+U7MBqnM2aeEk9M7xSoqGnu+wSdY6w==
+
 "@lerna/add@3.13.1":
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.13.1.tgz#2cd7838857edb3b43ed73e3c21f69a20beb9b702"


### PR DESCRIPTION
There already is an existing [FontAwesome plugin](https://www.npmjs.com/package/vuepress-plugin-font-awesome) but i found that it has a rather inconvenient usage. It generates one extra component for each icon which doesn't really match with how the official https://github.com/FortAwesome/vue-fontawesome Vue component works nowadays. So i decided to write our own updated version, which is based on the official https://github.com/markdown-it/markdown-it-emoji plugin.

- Markdown shorthand syntax similar to the emoji syntax: `:fas-coffee:`
- Supports all FontAwesome icons
- Uses the official vue-fontawesome components under the hood (enables tree-shaking to bundle used icons only)