### PR TITLE
feat(docgen): support es6+ JS builtins

### DIFF
--- a/packages/titanium-docgen/generators/jsca_generator.js
+++ b/packages/titanium-docgen/generators/jsca_generator.js
@@ -232,7 +232,7 @@ function exportType(api) {
 			rv = api.type;
 		}
 
-		if (rv.indexOf('Array') === 0) {
+		if (rv.indexOf('Array') === 0 && rv.indexOf('ArrayBuffer') !== 0) {
 			rv = 'Array';
 		} else if (rv.indexOf('Callback') === 0) {
 			rv = 'Function';

--- a/packages/titanium-docgen/generators/jsduck_generator.js
+++ b/packages/titanium-docgen/generators/jsduck_generator.js
@@ -222,7 +222,8 @@ function exportType(api) {
 			types = [ api.type ];
 		}
 		types.forEach(function (type) {
-			if (type.indexOf('Array') === 0) {
+			// Handle ArrayBuffer/Uint8Array/etc properly!
+			if (type.indexOf('Array<') === 0) {
 				rv.push(exportType({ type: type.slice(type.indexOf('<') + 1, type.lastIndexOf('>')) }) + '[]');
 			} else {
 				rv.push(type);

--- a/packages/titanium-docgen/lib/common.js
+++ b/packages/titanium-docgen/lib/common.js
@@ -32,8 +32,33 @@ exports.ADDON_VERSIONS = {
 	windowsphone: '4.1.0'
 };
 
-// TODO: Add null, undefined, Arguments, Function?
-exports.DATA_TYPES = [ 'Array', 'Boolean', 'Callback', 'Date', 'Dictionary', 'Number', 'Object', 'String', 'Error', 'RegExp' ];
+// TODO: Add null, undefined, Arguments, Infinity, NaN, Symbol, BigInt stuff?
+exports.DATA_TYPES = [
+	'Array',
+	'ArrayBuffer',
+	'Boolean',
+	'Callback', // alias for Function
+	'Date',
+	'Dictionary', // alias for generic JS Object
+	'Error',
+	'Float32Array',
+	'Float64Array',
+	'Function',
+	'Int16Array',
+	'Int32Array',
+	'Int8Array',
+	'Map',
+	'Number',
+	'Object',
+	'Promise',
+	'RegExp',
+	'Set',
+	'String',
+	'Uint16Array',
+	'Uint32Array',
+	'Uint8Array',
+	'Uint8ClampedArray'
+];
 exports.PRETTY_PLATFORM = {
 	android: 'Android',
 	blackberry: 'BlackBerry',

--- a/packages/titanium-docgen/lib/common.js
+++ b/packages/titanium-docgen/lib/common.js
@@ -32,33 +32,38 @@ exports.ADDON_VERSIONS = {
 	windowsphone: '4.1.0'
 };
 
-// TODO: Add null, undefined, Arguments, Infinity, NaN, Symbol, BigInt stuff?
-exports.DATA_TYPES = [
-	'Array',
+exports.SIMPLE_TYPES = [
 	'ArrayBuffer',
 	'Boolean',
-	'Callback', // alias for Function
 	'Date',
-	'Dictionary', // alias for generic JS Object
 	'Error',
 	'Float32Array',
 	'Float64Array',
-	'Function',
 	'Int16Array',
 	'Int32Array',
 	'Int8Array',
-	'Map',
 	'Number',
 	'Object',
-	'Promise',
 	'RegExp',
-	'Set',
 	'String',
 	'Uint16Array',
 	'Uint32Array',
 	'Uint8Array',
 	'Uint8ClampedArray'
 ];
+// Mapping from base type name to number of generic types required (0 means 0-Infinity)
+exports.COMPLEX_TYPES = new Map([
+	[ 'Array',  1 ],
+	[ 'Callback', 0 ], // alias for Function
+	[ 'Dictionary', 1 ], // alias for generic JS Object
+	[ 'Function', 0 ],
+	[ 'Map', 2 ],
+	[ 'Promise', 1 ],
+	[ 'Set', 1 ],
+]);
+
+// TODO: Add null, undefined, Arguments, Infinity, NaN, Symbol, BigInt stuff?
+exports.DATA_TYPES = [].concat(exports.SIMPLE_TYPES, Array.from(exports.COMPLEX_TYPES.keys()));
 exports.PRETTY_PLATFORM = {
 	android: 'Android',
 	blackberry: 'BlackBerry',

--- a/packages/titanium-docgen/validate.js
+++ b/packages/titanium-docgen/validate.js
@@ -374,7 +374,7 @@ function validateDataType(type, fullTypeContext) {
 		return errors;
 	}
 
-	// Check for compound types: Array<>, Callback<>, Function<>, Dictionary<>
+	// Check for compound types: Array<>, Callback<>, Function<>, Dictionary<>, Set<>, Promise<>, Map<>
 	const lessThanIndex = type.indexOf('<');
 	const greaterThanIndex = type.lastIndexOf('>');
 	if (lessThanIndex !== -1 && greaterThanIndex !== -1) {
@@ -384,7 +384,8 @@ function validateDataType(type, fullTypeContext) {
 		// Compound data type
 		const baseType = type.slice(0, lessThanIndex);
 		const subType = type.slice(lessThanIndex + 1, greaterThanIndex);
-		if (baseType === 'Callback' || baseType === 'Function') {
+		// TODO: Enforce Map can only have two subtypes
+		if (baseType === 'Callback' || baseType === 'Function' || baseType === 'Map') {
 			// functions can have multiple arguments as sub-types...
 			const errors = [];
 			subType.split(',').forEach(sub => {
@@ -392,8 +393,8 @@ function validateDataType(type, fullTypeContext) {
 			});
 			return errors;
 		}
-		// arrays and dictionaries can only have a single argument
-		if (baseType !== 'Array' && baseType !== 'Dictionary') {
+		// Arrays, Dictionaries, Sets and Promises can only have a single argument
+		if (baseType !== 'Array' && baseType !== 'Dictionary' && baseType !== 'Promise' && baseType !== 'Set') {
 			return [ new Problem(`Base type for complex types must be one of Array, Callback, Dictionary, Function, but received ${baseType}`) ];
 		}
 		// If we have an Array<Object> should we complain about that too?

--- a/packages/titanium-docgen/validate.js
+++ b/packages/titanium-docgen/validate.js
@@ -359,6 +359,26 @@ function validateConstant(constant) {
 }
 
 /**
+ * Parses the generic portion of a complex type string (the stuff inside the brackets)
+ * so for "Map<Number, String>", this would get "<Number, String>". Has to handle recursive complex types proeprly.
+ * @param {string} rawSubTypeString i.e. "Object", "void", "Map<Number, String>, Set<String>"
+ * @returns {string[]}
+ */
+function parseSubTypes(rawSubTypeString) {
+	const regex = /([^,<\s]+(<.+?>)?)/gm;
+	const types = [];
+	let m;
+	while ((m = regex.exec(rawSubTypeString)) !== null) {
+		// This is necessary to avoid infinite loops with zero-width matches
+		if (m.index === regex.lastIndex) {
+			regex.lastIndex++;
+		}
+		types.push(m[0]);
+	}
+	return types;
+}
+
+/**
  * Validate type
  * @param {string|string[]} type array of strings, or single string with a type name
  * @param {string|null} fullTypeContext full context of the type (for recursion), i.e. 'Callback<Object>' or 'Array<Object>'
@@ -378,48 +398,56 @@ function validateDataType(type, fullTypeContext) {
 	const lessThanIndex = type.indexOf('<');
 	const greaterThanIndex = type.lastIndexOf('>');
 	if (lessThanIndex !== -1 && greaterThanIndex !== -1) {
-		if (type === 'Callback<void>') {
-			return [];
-		}
 		// Compound data type
 		const baseType = type.slice(0, lessThanIndex);
-		const subType = type.slice(lessThanIndex + 1, greaterThanIndex);
-		// TODO: Enforce Map can only have two subtypes
-		if (baseType === 'Callback' || baseType === 'Function' || baseType === 'Map') {
-			// functions can have multiple arguments as sub-types...
-			const errors = [];
-			subType.split(',').forEach(sub => {
-				errors.push(...validateDataType(sub.trim(), type));
-			});
-			return errors;
+		if (!common.COMPLEX_TYPES.has(baseType)) {
+			return [ new Problem(`${baseType} is not a valid complex type, must be one of ${Array.from(common.COMPLEX_TYPES.keys())}: ${fullTypeContext || type}`) ];
 		}
-		// Arrays, Dictionaries, Sets and Promises can only have a single argument
-		if (baseType !== 'Array' && baseType !== 'Dictionary' && baseType !== 'Promise' && baseType !== 'Set') {
-			return [ new Problem(`Base type for complex types must be one of Array, Callback, Dictionary, Function, but received ${baseType}`) ];
+		const subTypes = parseSubTypes(type.slice(lessThanIndex + 1, greaterThanIndex));
+		const argCount = common.COMPLEX_TYPES.get(baseType);
+		// Enforce complex types have correct number of generics specified
+		if (argCount !== 0 && subTypes.length !== argCount) {
+			return [ new Problem(`${type} must have ${argCount} generic type(s) specified, but had ${subTypes.length}: ${fullTypeContext || type}`) ];
 		}
-		// If we have an Array<Object> should we complain about that too?
-		return validateDataType(subType, type);
+		// Special case for Callback<void> or Function<void>
+		if (argCount === 0 && subTypes.length === 1 && subTypes[0] === 'void') {
+			return [];
+		}
+		// check the generic types
+		const errors = [];
+		subTypes.forEach(sub => {
+			errors.push(...validateDataType(sub.trim(), type));
+		});
+		return errors;
 	}
 
-	// Warn about generic Dictonary/Object types
-	if ([ 'Dictionary', 'Object' ].includes(type)) {
-		// TODO: How can we mark/skip the valid cases here? Some APIs really do need to say "Object" as the arg/return value
-		return [ new Problem(`Please define a new type rather than using the generic Object/Dictionary references: ${fullTypeContext || type}`, WARNING) ];
-	}
+	// not written as a compound type...
+	const errors = [];
 
 	// Is this a built in Javascript type?
 	if (common.DATA_TYPES.includes(type)) {
-		return [];
+		// Should it have been written as a complex type?
+		if (common.COMPLEX_TYPES.has(type)) {
+			const argCount = common.COMPLEX_TYPES.get(type); // may be 0 if Function/Callback
+			// Enforce as ERROR if Promise/Set/Map doesn't have exact generic type count
+			const severity = [ 'Map', 'Set', 'Promise' ].includes(type) ? ERROR : WARNING;
+			errors.push(new Problem(`${type} ${severity === ERROR ? 'must' : 'should'} have ${argCount || 'any number of'} generic type(s) specified, but had 0: ${fullTypeContext || type}`, severity));
+		} else if (type === 'Object') {
+			// Warn about generic Object types (Dictionary is handled above as a complex type)
+			// TODO: How can we mark/skip the valid cases here? Some APIs really do need to say "Object" as the arg/return value
+			errors.push(new Problem(`Please define a new type rather than using the generic Object type reference: ${fullTypeContext || type}`, WARNING));
+		}
+		return errors;
 	}
 
 	// Is this a type in our APIDocs, or on our whitelist? (or are we on standalone mode?)
 	const possibleProblem = validateClass(type);
 	if (possibleProblem) {
-		return [ possibleProblem ];
+		errors.push(possibleProblem);
 	}
 
 	// class/type is fine or whitelisted
-	return [];
+	return errors;
 }
 
 /**


### PR DESCRIPTION
Support API docs referencing types: Promise, ArrayBuffer, Typed Arrays, Map, Set

Our docgen scripts and validation didn't know about newer built-in JS types. This was because the scripts were originally written before they were introduced **and** because our jsduck tooling for docs.appcelerator.com couldn't handle them.

I've added support for them in our jsduck fork on this branch: https://github.com/appcelerator/jsduck/commits/sgtcoolguy-es6

And I've created a local branch of appcelerator/doctools repo that consumes that to produce the doc site. It seemed to work fine once I generated the titanium.js file via this PR's docgen jsduck output.