### PR TITLE
fix: error version route

### DIFF
--- a/packages/vuepress/vuepress-plugin-versioning/index.js
+++ b/packages/vuepress/vuepress-plugin-versioning/index.js
@@ -96,7 +96,7 @@ module.exports = (options, context) => {
           const filePath = path.resolve(basePath, relative)
           pages.push({
             filePath,
-            relative
+            relative: relative.substring(relative.indexOf("/") + 1)
           })
         })
         return pages


### PR DESCRIPTION
There's an error versioning route for my project like this:

* version: 1.0.0, generated at:
	localhost:8080/1.0.0/1.0.0/
	
	because of relative path has included the version str and replaced into `/${version}/${path}`

I just remove the version in the relative path and work for me.