### PR TITLE
feat: allow editUrl

### DIFF
--- a/packages/vuepress/vuepress-theme-titanium/components/PageEdit.vue
+++ b/packages/vuepress/vuepress-theme-titanium/components/PageEdit.vue
@@ -53,6 +53,10 @@ export default {
         return
       }
 
+      if (!isNil(this.$page.frontmatter.editUrl)) {
+        return this.$page.frontmatter.editUrl
+      }
+
       const {
         repo,
         editLinks,


### PR DESCRIPTION
These changes are to:
- export an editUrl property in the api.json generated from titanium-docgen for json-raw output type. This url should point to the exact URL used to edit the underlying file. (this is generated by deconstructing the yml filepath that we used to generate the type to try and pull out the git repo's origin remote url and turn it into a GitHub edit url)
- Allow the titanium theme to use a page's frontmatter `editUrl` value as the edit this page link if it's not "nil" (`null`/`undefined`)

We'll also need to tweak the appcelerator/titanium-docs repo's migrate script to stick the editUrl into the generated page frontmatter.