### PR TITLE
fix(theme): use page relativePath to generate edit link

### DIFF
--- a/packages/vuepress/vuepress-plugin-versioning/index.js
+++ b/packages/vuepress/vuepress-plugin-versioning/index.js
@@ -156,8 +156,12 @@ module.exports = (options, context) => {
         } else {
           page.path = page.regularPath = generateVersionedPath(page.path, page.version, page._localePath)
         }
+        page.originalRelativePath = page.relativePath
+        page.relativePath = path.relative(versionedSourceDir, page._filePath).replace(/\\/g, '/')
       } else if (page._filePath.startsWith(pagesSourceDir)) {
         page.unversioned = true
+        page.originalRelativePath = page.relativePath
+        page.relativePath = path.relative(pagesSourceDir, page._filePath).replace(/\\/g, '/')
       } else if (page._filePath.startsWith(context.sourceDir)) {
         page.version = 'next'
         page.originalRegularPath = page.regularPath

--- a/packages/vuepress/vuepress-theme-titanium/components/PageEdit.vue
+++ b/packages/vuepress/vuepress-theme-titanium/components/PageEdit.vue
@@ -66,9 +66,8 @@ export default {
         docsDirPages = 'website/pages'
       } = this.$site.themeConfig
       let { docsDir = '' } = this.$site.themeConfig
-      let path = this.$page.regularPath
+      const path = this.$page.relativePath
       if (this.$page.version) {
-        path = this.$page.originalRegularPath
         if (this.$page.version !== 'next') {
           docsDir = docsDirVersioned
         }


### PR DESCRIPTION
Fixes #48

Note that I did not test this with the versioning plugin (since we don't yet use it!) It *may* break versioned urls. I suspect that versioned urls need more tweaking anyways, because I'm not sure how to trace back a version to the original source markdown file on GitHub unless you can somehow supply a mapping from version to branch names or something.