### PR TITLE
feat(theme): custom color theme for prism.js

### DIFF
--- a/packages/vuepress/vuepress-theme-titanium/styles/code.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/code.styl
@@ -142,41 +142,27 @@ div[class~="language-php"]:before
 // Custom Prism.js theme based on the Palenight High Contrast theme for VSCode,
 // enhanced with the colors from our theme.
 
-.token.attr-name
-	color $warning-lt
-
-.token.attr-value
-	color $success-lt
-
-.token.boolean
-	color #F78C6C
-
-.token.comment
-	color #676E95
-
-.token.constant
-	color $danger-lt
-
-.token.function
-	color:#82AAFF
-
-.token.keyword
-	color #c792ea
-
-.token.number
-	color #F78C6C
-
-.token.operator
-	color #89DDFF
-
-.token.punctuation
-	color #89DDFF
-
-.token.string
-	color $success-lt
-
-.token.tag
-	color $danger-lt
-
-.token.variable
-	color #A6ACCD
+.token
+  &.attr-name
+    color $warning-lt
+  &.attr-value,
+  &.char,
+  &.regex,
+  &.string,
+  &.variable
+	  color $success-lt
+  &.boolean,
+  &.number
+	  color #F78C6C
+  &.comment
+	  color #676E95
+  &.constant,
+  &.tag
+	  color $danger-lt
+  &.function
+	  color:#82AAFF
+  &.keyword
+	  color #c792ea
+  &.operator,
+  &.punctuation
+    color #89DDFF

--- a/packages/vuepress/vuepress-theme-titanium/styles/code.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/code.styl
@@ -25,7 +25,7 @@
     border-radius 6px
     overflow auto
     code
-      color #fff
+      color $gray-lt
       padding 0
       background-color transparent
       border-radius 0
@@ -34,6 +34,7 @@ div[class*="language-"]
   position relative
   background-color $codeBgColor
   border-radius 6px
+  -webkit-font-smoothing auto
   .highlight-lines
     user-select none
     padding-top 1.3rem
@@ -137,3 +138,45 @@ div[class~="language-bash"]:before
 
 div[class~="language-php"]:before
   content "php"
+
+// Custom Prism.js theme based on the Palenight High Contrast theme for VSCode,
+// enhanced with the colors from our theme.
+
+.token.attr-name
+	color $warning-lt
+
+.token.attr-value
+	color $success-lt
+
+.token.boolean
+	color #F78C6C
+
+.token.comment
+	color #676E95
+
+.token.constant
+	color $danger-lt
+
+.token.function
+	color:#82AAFF
+
+.token.keyword
+	color #c792ea
+
+.token.number
+	color #F78C6C
+
+.token.operator
+	color #89DDFF
+
+.token.punctuation
+	color #89DDFF
+
+.token.string
+	color $success-lt
+
+.token.tag
+	color $danger-lt
+
+.token.variable
+	color #A6ACCD

--- a/packages/vuepress/vuepress-theme-titanium/styles/code.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/code.styl
@@ -25,7 +25,7 @@
     border-radius 6px
     overflow auto
     code
-      color $gray-lt
+      color $primary-ltr
       padding 0
       background-color transparent
       border-radius 0
@@ -143,7 +143,9 @@ div[class~="language-php"]:before
 // enhanced with the colors from our theme.
 
 .token
-  &.attr-name
+  &.attr-name,
+  &.property
+  &.selector
     color $warning-lt
   &.attr-value,
   &.char,
@@ -159,10 +161,28 @@ div[class~="language-php"]:before
   &.constant,
   &.tag
 	  color $danger-lt
+  &.atrule
   &.function
-	  color:#82AAFF
+	  color #82AAFF
   &.keyword
-	  color #c792ea
+	  color $danger-lt
   &.operator,
   &.punctuation
     color #89DDFF
+
+.language-md
+  .token
+    &.title
+      color $warning-lt
+      &.important
+        font-weight 400
+    &.content
+      padding 0
+
+.language-css,
+.language-sass,
+.language-scss,
+.language-stylus,
+  .token
+    &.property
+      color #B2CCD6

--- a/packages/vuepress/vuepress-theme-titanium/styles/code.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/code.styl
@@ -155,7 +155,7 @@ div[class~="language-php"]:before
 	  color $success-lt
   &.boolean,
   &.number
-	  color #F78C6C
+	  color $warning
   &.comment
 	  color $gray-dk
   &.constant,

--- a/packages/vuepress/vuepress-theme-titanium/styles/code.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/code.styl
@@ -2,6 +2,7 @@
   code
     font-size .875rem
     font-weight 400
+    -webkit-font-smoothing auto
     line-height 1.5
     color $codeColor
     display inline-block
@@ -34,7 +35,6 @@ div[class*="language-"]
   position relative
   background-color $codeBgColor
   border-radius 6px
-  -webkit-font-smoothing auto
   .highlight-lines
     user-select none
     padding-top 1.3rem
@@ -157,7 +157,7 @@ div[class~="language-php"]:before
   &.number
 	  color #F78C6C
   &.comment
-	  color #676E95
+	  color $gray-dk
   &.constant,
   &.tag
 	  color $danger-lt
@@ -178,6 +178,16 @@ div[class~="language-php"]:before
         font-weight 400
     &.content
       padding 0
+
+.content
+  pre
+    &.language-yml
+      code
+        color $success-lt
+.language-yml
+  .token
+    &.atrule
+      color $danger-lt
 
 .language-css,
 .language-sass,

--- a/packages/vuepress/vuepress-theme-titanium/styles/palette.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/palette.styl
@@ -37,4 +37,4 @@ $accentColor = $danger
 $textColor = $black
 $lightTextColor = $gray-dk
 $borderColor = $black-ltr
-$codeBgColor = $black
+$codeBgColor = $secondary-dk


### PR DESCRIPTION
This tries to get the colors used in code snippets to match better with the colors from our theme. For that i took the Palenight High Contrast theme from VSCode as a base and changed some colors with the ones from our style guide.

I also enabled webkit font smoothing which makes the monospaced font in code block look a lot better in WebKit based browsers.