### PR TITLE
fix: properly handle falsy default values

### DIFF
--- a/packages/titanium-docgen/lib/common.js
+++ b/packages/titanium-docgen/lib/common.js
@@ -164,7 +164,7 @@ exports.setLogLevel = function setLogLevel(level) {
  * @return {boolean} true if the object has a value for the key (and if it's an array, it has to have at least one element)
  */
 exports.assertObjectKey = function assertObjectKey(obj, key) {
-	if (key in obj && obj[key]) {
+	if (Object.prototype.hasOwnProperty.call(obj, key)) {
 		if (Array.isArray(obj[key])) {
 			if (obj[key].length > 0) {
 				return true;

--- a/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
+++ b/packages/vuepress/vuepress-plugin-apidocs/components/PropertyList.vue
@@ -16,7 +16,7 @@
       <div class="member-summary" v-html="property.summary"></div>
       <div class="member-description" v-html="property.description"></div>
       <valid-constants v-if="property.constants" :constants="property.constants"/>
-      <p v-if="property.default">
+      <p v-if="property.default !== undefined">
         <strong>Default:</strong> <code><type-link :type="normalizeType(property.default)"/></code>
       </p>
       <hr v-if="index < properties.length - 1">
@@ -45,16 +45,28 @@ export default {
   },
   methods: {
     normalizeType (type) {
-      switch (typeof type) {
-        case 'undefined':
-          return 'undefined'
+      const typeName = typeof type
+      switch (typeName) {
         case 'boolean':
         case 'number':
           return type.toString()
-        case 'string':
-          return type.replace(/^<|>$/g, '')
+        case 'string': {
+          const cleanTypeName = type.replace(/^<|>$/g, '')
+          if (cleanTypeName === 'Undefined') {
+            return 'undefined'
+          } else {
+            return cleanTypeName
+          }
+        }
+        case 'object': {
+          if (type === null) {
+            return 'null'
+          } else {
+            return typeName
+          }
+        }
         default:
-          return type
+          return typeName
       }
     }
   }


### PR DESCRIPTION
Fixes `assertObjectKey` which would ignore keys which exists but have a falsy value. Also improves the display of default values for properties, which also would not show up if their value was falsy.