### PR TITLE
fix: fix color shades, sidebar sub groups and type meta padding

### DIFF
--- a/packages/vuepress/vuepress-plugin-apidocs/styles/main.styl
+++ b/packages/vuepress/vuepress-plugin-apidocs/styles/main.styl
@@ -5,7 +5,7 @@
     text-align right
   >.type-meta-value
     font-size: 0.875rem
-    margin: 0.5rem 0 0.875rem;
+    margin-bottom 0.75rem;
     text-align right
 .type-metas
   &>:last-child
@@ -16,7 +16,7 @@
   font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
   font-size: 0.875rem
   padding: 0.875rem 0.75rem
-  border-left 5px solid $gray
+  border-left 5px solid $black-ltr
 
 .content-loading
   margin 1rem 0

--- a/packages/vuepress/vuepress-theme-titanium/components/SidebarGroup.vue
+++ b/packages/vuepress/vuepress-theme-titanium/components/SidebarGroup.vue
@@ -127,6 +127,9 @@ export default {
   &.depth-2
     & > .sidebar-heading
       border-left-color transparent
+    &.is-sub-group
+      & > .sidebar-heading
+        border-left 0
 
 .sidebar-heading
   color $textColor

--- a/packages/vuepress/vuepress-theme-titanium/styles/table.styl
+++ b/packages/vuepress/vuepress-theme-titanium/styles/table.styl
@@ -5,7 +5,7 @@ table
   border-collapse: collapse;
   border-spacing: 0;
   tr
-    border-bottom: 1px solid $gray
+    border-bottom: 1px solid $black-ltr
   tbody tr:last-child
       border-bottom 0
   td, th


### PR DESCRIPTION
This changes a couple of styles:

- Use a lighter shade of grey for table borders and the type signature left border
- Fix level 2 sub group heading which were slightly shifted
- Lower the margin between type metadata to save vertical space