### PR TITLE
Reduce jsca file size

### DIFF
--- a/packages/titanium-docgen/index.js
+++ b/packages/titanium-docgen/index.js
@@ -15,8 +15,6 @@ var yaml = require('js-yaml');
 var exec = require('child_process').exec; // eslint-disable-line security/detect-child-process
 var os = require('os');
 var pathMod = require('path');
-var accessorsDeprecatedSince = '';
-var accessorsRemovedSince = '';
 var assert = common.assertObjectKey;
 var basePaths = [];
 var processFirst = [ 'Titanium.Proxy', 'Titanium.Module', 'Titanium.UI.View' ];
@@ -305,7 +303,6 @@ function hideAPIMembers(apis, type) {
 	}
 	return apis;
 }
-
 
 /**
  * Returns a subtype based on the parent class
@@ -804,17 +801,6 @@ if (~formats.indexOf('addon') && !searchPlatform) {
 if (basePaths.length === 0) {
 	common.log(common.LOG_ERROR, 'Specify at least one path where to look for YAML files.');
 	process.exit(1);
-}
-
-const sdkPackageJson = pathMod.resolve(basePaths[0], '..', 'package.json');
-if (fs.existsSync(sdkPackageJson)) {
-	version = require(sdkPackageJson).version;
-	if (nodeappc.version.gte(version, '8.0.0')) {
-		accessorsDeprecatedSince = '8.0.0';
-	}
-	if (nodeappc.version.gte(version, '10.0.0')) {
-		accessorsRemovedSince = '10.0.0';
-	}
 }
 
 // Parse YAML files

--- a/packages/titanium-docgen/index.js
+++ b/packages/titanium-docgen/index.js
@@ -1103,7 +1103,7 @@ formats.forEach(function (format) {
 			output = pathMod.join(output, 'index.html');
 			break;
 		case 'jsca' :
-			render = JSON.stringify(exportData, null, '    ');
+			render = JSON.stringify(exportData, null);
 			output = pathMod.join(outputPath, 'api.jsca');
 			break;
 		case 'json' :


### PR DESCRIPTION
This reduced the JSCA file size from ~34MB to ~8MB by doing the following:

* Don't pretty print the file, just have a nice lovely minified blob of JSON
* No longer generate the accessors for every property, as the SDK doesn't anymore
	* Technically a breaking change

The file produced by this has been verified to work with both the editors and Studio