### PR TITLE
update links and fix raw-json generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This is a monorepo with the following packages:
 ## Contributing
 
 Open source contributions are greatly appreciated! If you have a bugfix, improvement or new feature, please create
-[an issue](https://github.com/appcelerator/docs-devkit/issues/new) first and submit a [pull request](https://github.com/appcelerator/docs-devkit/pulls/new) against master.
+[an issue](https://github.com/tidev/docs-devkit/issues/new) first and submit a [pull request](https://github.com/tidev/docs-devkit/pulls/new) against master.
 
 Before you contribute read through the following guidelines.
 
@@ -34,8 +34,8 @@ Before you contribute read through the following guidelines.
 ## Getting Help
 
 If you have questions about our documentation devkit for VuePress, feel free to reach out on Stackoverflow or the
-`#helpme` channel on [TiSlack](http://tislack.org). In case you find a bug, create a [new issue](https://github.com/appcelerator/docs-devkit/issues/new)
-or open a [new JIRA ticket](https://jira.appcelerator.org).
+`#helpme` channel on [TiSlack](http://tislack.org). In case you find a bug, create a [new issue](https://github.com/tidev/docs-devkit/issues/new)
+or open a [new ticket](https://github.com/tidev/titanium-sdk/issues/new).
 
 ## License
 

--- a/packages/docs/docs/.vuepress/config.js
+++ b/packages/docs/docs/.vuepress/config.js
@@ -13,14 +13,13 @@ module.exports = context => ({
     footerLogo: '/axway-appcelerator-logo.png',
     footerSitemap: {
       'Products': [
-        { text: 'Titanium SDK', link: 'https://github.com/appcelerator/titanium_mobile' },
-        { text: 'Alloy', link: 'https://github.com/appcelerator/alloy' },
-        { text: 'Titanium Vue', link: 'https://github.com/appcelerator/titanium-vue' },
-        { text: 'Titanium Angular', link: 'https://github.com/appcelerator/titanium-angular' }
+        { text: 'Titanium SDK', link: 'https://github.com/tidev/titanium_mobile' },
+        { text: 'Alloy', link: 'https://github.com/tidev/alloy' },
+        { text: 'Titanium Vue', link: 'https://github.com/tidev/titanium-vue' },
+        { text: 'Titanium Angular', link: 'https://github.com/tidev/titanium-angular' }
       ],
       'Social': [
-        { text: 'Twitter', link: 'https://twitter.com/appcelerator' },
-        { text: 'LinkedIn', link: 'https://linkedin.com/company/axway' }
+        { text: 'Twitter', link: 'https://x.com/TitaniumSDK/' }
       ]
     },
     repo: 'appcelerator/docs-devkit',

--- a/packages/docs/docs/guide/README.md
+++ b/packages/docs/docs/guide/README.md
@@ -4,7 +4,7 @@ sidebarDepth: 0
 
 # Introduction
 
-The Titanium Docs DevKit for VuePress is composed of a [theme](../theme/README.md) and two [plugins](../plugins/README.md). It was mainly created to modernize the documentation needs of [Titanium](https://github.com/appcelerator/titanium_mobile) and make it easier for the community to contribute to our open source projects.
+The Titanium Docs DevKit for VuePress is composed of a [theme](../theme/README.md) and two [plugins](../plugins/README.md). It was mainly created to modernize the documentation needs of [Titanium](https://github.com/tidev/titanium-sdk) and make it easier for the community to contribute to our open source projects.
 
 ::: tip
 You can see the plugins and theme in action on this very site.

--- a/packages/docs/docs/guide/api-docs.md
+++ b/packages/docs/docs/guide/api-docs.md
@@ -7,7 +7,7 @@ metadataKey: SomeType
 Writing complex API documentation is often quite cumbersome in markdown. This is where the API docs plugin steps it. It provides a `<ApiDocs/>` tag which can render extensive API documentation from a metadata file.
 
 ::: warning COMPATIBILTY NOTE
-This plugin is currently limited to a specific metadata format called [TDoc](https://docs.appcelerator.com/platform/latest/#!/guide/TDoc_Specification) that is used to document our [Titanium SDK](https://github.com/appcelerator/titanium_mobile). It is optimized for our specific needs and object structure but may also be used to document any other types that can be represented in the TDoc spec.
+This plugin is currently limited to a specific metadata format called [TDoc](https://docs.appcelerator.com/platform/latest/#!/guide/TDoc_Specification) that is used to document our [Titanium SDK](https://github.com/tidev/titanium-sdk). It is optimized for our specific needs and object structure but may also be used to document any other types that can be represented in the TDoc spec.
 :::
 
 ## Getting Started

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -1,8 +1,8 @@
 {
   "name": "docs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Docs for the Titanium docs-devkit",
-  "repository": "https://github.com/appcelerator/docs-devkit.git",
+  "repository": "https://github.com/tidev/docs-devkit.git",
   "author": "Axway Appcelerator",
   "license": "Apache-2.0",
   "private": true,
@@ -17,9 +17,9 @@
     "@vuepress/plugin-back-to-top": "1.8.2",
     "fs-extra": "^9.0.1",
     "vuepress": "^1.7.1",
-    "vuepress-plugin-apidocs": "^5.0.0",
-    "vuepress-plugin-versioning": "^5.0.0",
-    "vuepress-theme-titanium": "^5.0.0",
+    "vuepress-plugin-apidocs": "^5.0.1",
+    "vuepress-plugin-versioning": "^5.0.1",
+    "vuepress-theme-titanium": "^5.0.1",
     "vuex": "^3.5.1",
     "vuex-router-sync": "^5.0.0"
   }

--- a/packages/docs/website/versioned_docs/0.1.3/guide/README.md
+++ b/packages/docs/website/versioned_docs/0.1.3/guide/README.md
@@ -4,7 +4,7 @@ sidebarDepth: 0
 
 # Introduction
 
-The Titanium Docs DevKit for VuePress is composed of a [theme](../theme/README.md) and two [plugins](../plugins/README.md). It was mainly created to modernize the documentation needs of [Titanium](https://github.com/appcelerator/titanium_mobile) and make it easier for the community to contribute to our open source projects.
+The Titanium Docs DevKit for VuePress is composed of a [theme](../theme/README.md) and two [plugins](../plugins/README.md). It was mainly created to modernize the documentation needs of [Titanium](https://github.com/tidev/titanium-sdk) and make it easier for the community to contribute to our open source projects.
 
 ::: tip
 You can see the plugins and theme in action on this very site.

--- a/packages/docs/website/versioned_docs/0.1.3/guide/api-docs.md
+++ b/packages/docs/website/versioned_docs/0.1.3/guide/api-docs.md
@@ -7,7 +7,7 @@ metadataKey: SomeType
 Writing complex API documentation is often quite cumbersome in markdown. This is where the API docs plugin steps it. It provides a `<ApiDocs/>` tag which can render extensive API documentation from a metadata file.
 
 ::: warning COMPATIBILTY NOTE
-This plugin is currently limited to a specific metadata format called [TDoc](https://docs.appcelerator.com/platform/latest/#!/guide/TDoc_Specification) that is used to document our [Titanium SDK](https://github.com/appcelerator/titanium_mobile). It is optimized for our specific needs and object structure but may also be used to document any other types that can be represented in the TDoc spec.
+This plugin is currently limited to a specific metadata format called [TDoc](https://docs.appcelerator.com/platform/latest/#!/guide/TDoc_Specification) that is used to document our [Titanium SDK](https://github.com/tidev/titanium-sdk). It is optimized for our specific needs and object structure but may also be used to document any other types that can be represented in the TDoc spec.
 :::
 
 ## Getting Started

--- a/packages/titanium-docgen/generators/json-raw_generator.js
+++ b/packages/titanium-docgen/generators/json-raw_generator.js
@@ -245,10 +245,10 @@ function getRepoUrl(filepath) {
 		return REPO_URLS.get(filepath);
 	}
 	const stdout = exec('git config --get remote.origin.url', { cwd: filepath }).toString().trim();
-	const m = stdout.match(/^(git@|https:\/\/)github.com[:/]([\w-]+)\/([\w_\-.]+)\.git$/);
+	const m = stdout.match(/^(git@|https:\/\/)github.com[:/]([\w-]+)\/([\w_\-.]+?)(?:\.git)?$/);
 	if (!m) {
 		console.log(`Unable to pull github org/repo from url: ${stdout}`);
-		const result = 'https://github.com/appcelerator/titanium_mobile/edit/master/';
+		const result = 'https://github.com/tidev/titanium-sdk/edit/main/';
 		REPO_URLS.set(filepath, result);
 		return result;
 	}

--- a/packages/titanium-docgen/generators/typescript_generator.js
+++ b/packages/titanium-docgen/generators/typescript_generator.js
@@ -362,8 +362,8 @@ class GlobalTemplateWriter {
 		const versionSplit = this.version.split('.');
 		const majorMinor = `${versionSplit[0]}.${versionSplit[1]}`;
 		this.output += `// Type definitions for non-npm package Titanium ${majorMinor}\n`;
-		this.output += '// Project: https://github.com/appcelerator/titanium_mobile\n';
-		this.output += '// Definitions by: Axway Appcelerator <https://github.com/appcelerator>\n';
+		this.output += '// Project: https://github.com/tidev/titanium-sdk\n';
+		this.output += '// Definitions by: TiDev, Inc. <https://github.com/tidev>\n';
 		this.output += '//                 Jan Vennemann <https://github.com/janvennemann>\n';
 		this.output += '//                 Mathias Lorenzen <https://github.com/ffMathy>\n';
 		this.output += '// Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped\n';

--- a/packages/titanium-docgen/package.json
+++ b/packages/titanium-docgen/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titanium-docgen",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Generates Titanium API documentation in different formats",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "url": "https://github.com/tidev/docs-devkit.git",
     "directory": "packages/titanium-docgen"
   },
   "dependencies": {

--- a/packages/vuepress/vuepress-plugin-apidocs/package.json
+++ b/packages/vuepress/vuepress-plugin-apidocs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-plugin-apidocs",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Plugin for VuePress to render API reference documentation",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "url": "https://github.com/tidev/docs-devkit.git",
     "directory": "packages/vuepress/vuepress-plugin-apidocs"
   },
   "dependencies": {

--- a/packages/vuepress/vuepress-plugin-fontawesome/package.json
+++ b/packages/vuepress/vuepress-plugin-fontawesome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@titanium-sdk/vuepress-plugin-fontawesome",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "FontAwesome plugin for VuePress",
   "main": "index.js",
   "scripts": {
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "url": "https://github.com/tidev/docs-devkit.git",
     "directory": "packages/vuepress/vuepress-plugin-fontawesome"
   },
   "dependencies": {

--- a/packages/vuepress/vuepress-plugin-versioning/package.json
+++ b/packages/vuepress/vuepress-plugin-versioning/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-plugin-versioning",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Versioning plugin for VuePress",
   "main": "index.js",
   "scripts": {
@@ -16,7 +16,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "url": "https://github.com/tidev/docs-devkit.git",
     "directory": "packages/vuepress/vuepress-plugin-versioning"
   },
   "dependencies": {

--- a/packages/vuepress/vuepress-theme-titanium/package.json
+++ b/packages/vuepress/vuepress-theme-titanium/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuepress-theme-titanium",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "VuePress theme for Titanium projects",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/appcelerator/docs-devkit.git",
+    "url": "https://github.com/tidev/docs-devkit.git",
     "directory": "packages/vuepress/vuepress-theme-titanium"
   },
   "dependencies": {


### PR DESCRIPTION
fixes https://github.com/tidev/titanium-docs/issues/258

* fix regex in `json-raw_generator.js` to ignore `.git` (see issue above for explanation) 
* fix fallback url in `json-raw_generator.js`
* search & replaced some old appcelerator links
* update package versions to 5.0.1